### PR TITLE
Add reset() method to allow getting different transformations with the same ImageUrl-instance

### DIFF
--- a/library/ImboClient/ImageUrl/ImageUrl.php
+++ b/library/ImboClient/ImageUrl/ImageUrl.php
@@ -179,6 +179,15 @@ class ImageUrl implements ImageUrlInterface {
     }
 
     /**
+     * @see ImboClient\ImageUrl\ImageUrlInterface::reset()
+     */
+    public function reset() {
+        $this->data = array();
+        $this->imageIdentifier = substr($this->imageIdentifier, 0, 32);
+        return $this;
+    }
+
+    /**
      * @see ImboClient\ImageUrl\ImageUrlInterface::__toString()
      */
     public function __toString() {

--- a/library/ImboClient/ImageUrl/ImageUrlInterface.php
+++ b/library/ImboClient/ImageUrl/ImageUrlInterface.php
@@ -144,6 +144,13 @@ interface ImageUrlInterface {
     function thumbnail($width = 50, $height = 50, $fit = 'outbound');
 
     /**
+     * Resets the URL - removes all transformations
+     *
+     * @return ImboClient\ImageUrl\ImageUrlInterface
+     */
+    function reset();
+
+    /**
      * Represent the complete image url as a string
      *
      * @return string

--- a/tests/ImboClient/ImageUrl/ImageUrlTest.php
+++ b/tests/ImboClient/ImageUrl/ImageUrlTest.php
@@ -64,7 +64,7 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
         $this->assertStringEndsWith('?t[]=border:color=fff,width=2,height=3', (string) $this->url);
     }
 
-    public function testCompess() {
+    public function testCompress() {
         $this->assertSame($this->url, $this->url->compress());
         $this->assertStringEndsWith('?t[]=compress:quality=75', (string) $this->url);
     }
@@ -137,5 +137,11 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
     public function testThumbnailWithAllParams() {
         $this->assertSame($this->url, $this->url->thumbnail(1, 2, 'inset'));
         $this->assertStringEndsWith('?t[]=thumbnail:width=1,height=2,fit=inset', (string) $this->url);
+    }
+
+    public function testResetUrl() {
+        $this->url->thumbnail(1, 2, 'inset')->png();
+        $this->assertSame($this->url, $this->url->reset());
+        $this->assertStringEndsWith($this->imageIdentifier, (string) $this->url);
     }
 }


### PR DESCRIPTION
Added reset()-method to ImageUrl-class and interface. Added test to make sure it actually does its job.
