### PR TITLE
Valid query params

### DIFF
--- a/library/ImboClient/ImageUrl/ImageUrl.php
+++ b/library/ImboClient/ImageUrl/ImageUrl.php
@@ -250,9 +250,9 @@ class ImageUrl implements ImageUrlInterface {
     private function getQueryString() {
         $query = null;
         $query = array_reduce($this->data, function($query, $element) {
-            return $query . 't[]=' . $element . '&';
+            return $query . 't%5B%5D=' . $element . '&amp;'; // %5B => [] <= %5D
         }, $query);
-        $query = rtrim($query, '&');
+        $query = rtrim($query, '&amp;');
 
         return $query;
     }


### PR DESCRIPTION
Modified ImageUrl.php's getQueryString() generate valid URL query string, as validators complain about "[", "]" and "&".
