### PR TITLE
Use the correct standard with PHP_CodeSniffer

### DIFF
--- a/build.xml.dist
+++ b/build.xml.dist
@@ -50,7 +50,7 @@
 
   <target name="phpcs" description="Generate checkstyle.xml using PHP_CodeSniffer">
     <exec executable="phpcs">
-      <arg line="--report=checkstyle --report-file=${build}/logs/checkstyle.xml --standard=CE ${source}"/>
+      <arg line="--report=checkstyle --report-file=${build}/logs/checkstyle.xml --standard=Imbo ${source}"/>
     </exec>
   </target>
 


### PR DESCRIPTION
Changed the standard used with phpcs to Imbo.
