### PR TITLE
Use addQueryParam directly

### DIFF
--- a/library/ImboClient/Client.php
+++ b/library/ImboClient/Client.php
@@ -292,9 +292,9 @@ class Client implements ClientInterface {
 
         $url = $this->getImagesUrl();
 
-        // Loop through the params and set custom query params via __call on the URL instance
+        // Add query params
         foreach ($params as $key => $value) {
-            $url->$key($value);
+            $url->addQueryParam($key, $value);
         }
 
         // Fetch the response


### PR DESCRIPTION
Use the `addQueryParam` method directly instead of via the magic `__call` method
