### PR TITLE
Fixed a bug where CURLOPT_FOLLOWLOCATION would cause the response to inc...

### DIFF
--- a/library/ImboClient/Driver/Curl.php
+++ b/library/ImboClient/Driver/Curl.php
@@ -270,7 +270,11 @@ class Curl implements DriverInterface {
         }
 
         // Remove any HTTP/1.1 100 Continue from the response
-        $content = preg_replace('/HTTP\/[.\d]+ 100.*?^HTTP/sm', 'HTTP', $content);
+        $content = preg_replace('/HTTP\/[.\d]+ 100 .*?\r\n\r\n/sm', '', $content);
+
+        // Curl will include headers from all requests if hitting 3xx responses (and CURLOPT_FOLLOWLOCATION is on)
+        // Strip away all 3xx-header sets from the content, leaving only the last set of headers and the body
+        $content = preg_replace('/^HTTP\/[.\d]+ 3\d+.*?\r\n\r\n/sm', '', $content);
 
         list($headers, $body) = explode("\r\n\r\n", $content, 2);
 


### PR DESCRIPTION
...lude several HTTP header blocks when hitting a 3xx-response from the server. The curl driver would fail to separate the body from the headers.
