### PR TITLE
Drop sudo from the before_script command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ branches:
     - develop
     - master
 before_script:
-  - "sudo gem install nokogiri"
+  - "gem install nokogiri"
 script: rake travis


### PR DESCRIPTION
This PR should no longer cause Travis-CI to mark the build as failed
