### PR TITLE
Fixed bug regarding some SSL options

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,6 +5,7 @@ ImboClient-0.7.0
 ----------------
 __N/A__
 
+* Fixed issue #68: SSL issues because some options are set when they are empty
 * Pull request #66: getImageProperties should return more information
 * Pull request #65: Implemented the imageIdentifierExists()-method.
 * Pull request #63: Add support for desaturate transformation (Espen Hovlandsdal)

--- a/library/ImboClient/Driver/cURL.php
+++ b/library/ImboClient/Driver/cURL.php
@@ -252,9 +252,15 @@ class cURL implements DriverInterface {
             $options += array(
                 CURLOPT_SSL_VERIFYPEER => $this->params['sslVerifyPeer'],
                 CURLOPT_SSL_VERIFYHOST => $this->params['sslVerifyHost'],
-                CURLOPT_CAINFO         => $this->params['sslCaInfo'],
-                CURLOPT_CAPATH         => $this->params['sslCaPath'],
             );
+
+            if ($this->params['sslCaInfo']) {
+                $options[CURLOPT_CAINFO] = $this->params['sslCaInfo'];
+            }
+
+            if ($this->params['sslCaPath']) {
+                $options[CURLOPT_CAPATH] = $this->params['sslCaPath'];
+            }
         }
 
         curl_setopt_array($handle, $options);


### PR DESCRIPTION
Don't set options unless they contain values. Also updated the ChangeLog. Fixes #68
