### PR TITLE
Image class should expect dates as strings 

### DIFF
--- a/library/ImboClient/Url/Images/Image.php
+++ b/library/ImboClient/Url/Images/Image.php
@@ -251,21 +251,21 @@ class Image implements ImageInterface {
     }
 
     /**
-     * Set date when image was added to the server, as unix timestamp
+     * Set date when image was added to the server
      *
-     * @param int $added
+     * @param string $added
      */
     private function setAddedDate($added) {
-        $this->addedDate = new DateTime('@' . (int) $added);
+        $this->addedDate = DateTime::createFromFormat('D, d M Y H:i:s T', $added);
     }
 
     /**
-     * Set date when image was last updated on the server, as unix timestamp
+     * Set date when image was last updated on the server
      *
-     * @param int $updated
+     * @param string $updated
      */
     private function setUpdatedDate($updated) {
-        $this->updatedDate = new DateTime('@' . (int) $updated);
+        $this->updatedDate = DateTime::createFromFormat('D, d M Y H:i:s T', $updated);
     }
 
     /**

--- a/tests/ImboClient/Url/Images/ImageTest.php
+++ b/tests/ImboClient/Url/Images/ImageTest.php
@@ -56,12 +56,12 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
         'size'            => 655114,
         'extension'       => 'png',
         'mime'            => 'image/png',
-        'added'           => 1328559645,
+        'added'           => 'Thu, 15 Nov 2012 16:58:06 GMT',
         'width'           => 640,
         'height'          => 480,
         'checksum'        => '995b506ba1772e6a3fa25a2e3e618b08',
         'publicKey'       => 'testsuite',
-        'updated'         => 1328559945,
+        'updated'         => 'Thu, 15 Nov 2012 16:58:06 GMT',
     );
 
     /**
@@ -127,8 +127,8 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
      * @covers ImboClient\Url\Images\Image::getAddedDate
      * @covers ImboClient\Url\Images\Image::setAddedDate
      */
-    public function testCanGetAddedDateAsDatetimeInstanceAfterBeingPopulatedThroughConstructorAsUnixTimestamp() {
-        $added = new DateTime('@' . $this->data['added']);
+    public function testCanGetAddedDateAsDatetimeInstanceAfterBeingPopulatedThroughConstructorAsFormattedString() {
+        $added = DateTime::createFromFormat('D, d M Y H:i:s T', $this->data['added']);
         $this->assertEquals($added, $this->image->getAddedDate());
     }
 
@@ -138,8 +138,8 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
      * @covers ImboClient\Url\Images\Image::getUpdatedDate
      * @covers ImboClient\Url\Images\Image::setUpdatedDate
      */
-    public function testCanGetUpdatedDateAsDatetimeInstanceAfterBeingPopulatedThroughConstructorAsUnixTimestamp() {
-        $updated = new DateTime('@' . $this->data['updated']);
+    public function testCanGetUpdatedDateAsDatetimeInstanceAfterBeingPopulatedThroughConstructorAsFormattedString() {
+        $updated = DateTime::createFromFormat('D, d M Y H:i:s T', $this->data['updated']);
         $this->assertEquals($updated, $this->image->getUpdatedDate());
     }
 


### PR DESCRIPTION
Fixed Image class to expect date as strings instead of unix timestamps (changed in 523da96).
