### PR TITLE
Only add commit hash to version string when in the develop branch

### DIFF
--- a/library/ImboClient/Version.php
+++ b/library/ImboClient/Version.php
@@ -58,10 +58,13 @@ class Version {
         if (self::$version === null) {
             self::$version = self::VERSION;
 
-            if (is_dir(dirname(dirname(__DIR__)) . '/.git')) {
+            if (self::$version === 'dev' && is_dir(__DIR__ . '/../../.git')) {
                 // We have a git checkout. Add commit hash
+                $current = getcwd();
+                chdir(__DIR__ . '/../../.git');
                 $hash = exec('git rev-parse --short HEAD');
                 self::$version .= '-' . $hash;
+                chdir($current);
             }
         }
 

--- a/tests/ImboClient/VersionTest.php
+++ b/tests/ImboClient/VersionTest.php
@@ -77,7 +77,8 @@ class VersionTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * The version component must be able to report the correct version after the internal property has been changed. This is done by the PEAR installer when the package is installed.
+     * The version component must be able to report the correct version after the internal property
+     * has been changed.
      *
      * @covers ImboClient\Version::getVersionNumber
      * @covers ImboClient\Version::getVersionString


### PR DESCRIPTION
This PR changes the version component so that it adds the commit hash to the version string only when the user in the develop branch and the .git directory exists.
