### PR TITLE
Changed parameter name in the compress transformation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -468,7 +468,7 @@ The available transformation methods are:
 * ``autoRotate()``
 * ``border($color = '000000', $width = 1, $height = 1, $mode = 'outbound')``
 * ``canvas($width, $height, $mode = null, $x = null, $y = null, $bg = null)``
-* ``compress($quality = 75)``
+* ``compress($level = 75)``
 * ``crop($x, $y, $width, $height)``
 * ``desaturate()``
 * ``flipHorizontally()``

--- a/src/ImboClient/Http/ImageUrl.php
+++ b/src/ImboClient/Http/ImageUrl.php
@@ -113,11 +113,11 @@ class ImageUrl extends Url {
     /**
      * Add a compress transformation
      *
-     * @param int $quality A value between 0 and 100 where 100 is the best
+     * @param int $level A value between 0 and 100 where 100 is the best
      * @return self
      */
-    public function compress($quality = 75) {
-        return $this->addTransformation(sprintf('compress:quality=%d', (int) $quality));
+    public function compress($level = 75) {
+        return $this->addTransformation(sprintf('compress:level=%d', (int) $level));
     }
 
     /**

--- a/tests/ImboClientTest/Http/ImageUrlTest.php
+++ b/tests/ImboClientTest/Http/ImageUrlTest.php
@@ -53,7 +53,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
             'border' => array('border', null, $this->baseUrl . '?t%5B0%5D=border%3Acolor%3D000000%2Cwidth%3D1%2Cheight%3D1%2Cmode%3Doutbound'),
             'canvas' => array('canvas', array(100, 200), $this->baseUrl . '?t%5B0%5D=canvas%3Awidth%3D100%2Cheight%3D200'),
             'canvas with all params' => array('canvas', array(100, 200, 'center', 10, 20, 'fff'), $this->baseUrl . '?t%5B0%5D=canvas%3Awidth%3D100%2Cheight%3D200%2Cmode%3Dcenter%2Cx%3D10%2Cy%3D20%2Cbg%3Dfff'),
-            'compress' => array('compress', null, $this->baseUrl . '?t%5B0%5D=compress%3Aquality%3D75'),
+            'compress' => array('compress', null, $this->baseUrl . '?t%5B0%5D=compress%3Alevel%3D75'),
             'convert' => array('convert', array('png'), $this->baseUrl . '.png'),
             'gif conversion' => array('gif', null, $this->baseUrl . '.gif'),
             'jpg conversion' => array('jpg', null, $this->baseUrl . '.jpg'),


### PR DESCRIPTION
The `quality` parameter of the compress transformation has been renamed to `level`.
