### PR TITLE
wrong url when using maxSize transformation

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,6 +1,14 @@
 Changelog for ImboClient
 ========================
 
+ImboClient-1.1.1
+----------------
+__N/A__
+
+Bug fixes:
+
+* #90: Imbo\Http\ImageUrl instances does not support being converted to strings more than once
+
 ImboClient-1.1.0
 ----------------
 __2014-02-13__

--- a/src/ImboClient/Http/ImageUrl.php
+++ b/src/ImboClient/Http/ImageUrl.php
@@ -409,8 +409,9 @@ class ImageUrl extends Url {
             $this->path = preg_replace('#(\.(gif|jpg|png))?$#', '.' . $this->extension, $this->path);
         }
 
-        // Append transformations
-        $this->query->add('t', $this->transformations);
+        // Set the t query param, overriding it if it already exists, which it might do if the
+        // string has already been converted to a string
+        $this->query->set('t', $this->transformations);
 
         return parent::__toString();
     }

--- a/tests/ImboClientTest/Http/ImageUrlTest.php
+++ b/tests/ImboClientTest/Http/ImageUrlTest.php
@@ -328,4 +328,15 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
             $this->assertSame($exceptionMessage, $e->getMessage());
         }
     }
+
+    /**
+     * @see https://github.com/imbo/imboclient-php/issues/90
+     */
+    public function testUrlsCanGetConvertedToStringsMoreThanOnce() {
+        $this->url->setPrivateKey('key');
+        $this->url->maxSize(123, 123);
+
+        $this->assertSame('http://imbo/users/christer/images/image?t%5B0%5D=maxSize%3Awidth%3D123%2Cheight%3D123&accessToken=ae738aa84615093e78c635fbbdbef4debb177346a956eb4cefe50bc83592da70', (string) $this->url);
+        $this->assertSame((string) $this->url, (string) $this->url);
+    }
 }

--- a/tests/ImboClientTest/Http/UrlTest.php
+++ b/tests/ImboClientTest/Http/UrlTest.php
@@ -49,4 +49,14 @@ class UrlTest extends \PHPUnit_Framework_TestCase {
         $urlInstance = Url::factory($url, $privateKey);
         $this->assertSame($urlWithToken, (string) $urlInstance);
     }
+
+    /**
+     * @see https://github.com/imbo/imboclient-php/issues/90
+     */
+    public function testUrlsCanGetConvertedToStringsMoreThanOnce() {
+        $urlInstance = Url::factory('http://imbo/users/christer.json', 'key');
+
+        $this->assertSame('http://imbo/users/christer.json?accessToken=b85f9a8c2ffd2eb6a550b259e417686cf63b567b2b6972630b8e8519f6bb06b9', (string) $urlInstance);
+        $this->assertSame((string) $urlInstance, (string) $urlInstance);
+    }
 }


### PR DESCRIPTION
hi, it's me again :)

i use maxSize transformation for profile pictures, the php looks like this

```
$this->imbo->getImageUrl($imageId)->maxSize($width, $height);
```

but in the resulting url the transform is listed twice. 

domain/users/golf/images/imageId?t[0]=maxSize:width=150,height=150&t[1][0]=maxSize:width=150,height=150&accessToken=accessToken

when fetched i get Invalid transformation error. when i delete the part after &t[1][0] i get incorrect token error, which is not true as without the transformation the image displays

it's doing that on both master and develop branch. i've also updated the server part, but it still persists
