### PR TITLE
Image extension is replicated when a URL is converted to a string more than once

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -7,6 +7,7 @@ __N/A__
 
 Bug fixes:
 
+* #91: Image extension is replicated when a URL is converted to a string more than once
 * #90: Imbo\Http\ImageUrl instances does not support being converted to strings more than once
 
 ImboClient-1.1.0

--- a/src/ImboClient/Http/ImageUrl.php
+++ b/src/ImboClient/Http/ImageUrl.php
@@ -406,7 +406,8 @@ class ImageUrl extends Url {
     public function __toString() {
         // Update the path
         if ($this->extension) {
-            $this->path = preg_replace('#(\.(gif|jpg|png))?$#', '.' . $this->extension, $this->path);
+            // Remove a possible extension in the path, and append the new one
+            $this->path = preg_replace('#(\.(gif|jpg|png))$#', '', $this->path) . '.' . $this->extension;
         }
 
         // Set the t query param, overriding it if it already exists, which it might do if the

--- a/tests/ImboClientTest/Http/ImageUrlTest.php
+++ b/tests/ImboClientTest/Http/ImageUrlTest.php
@@ -339,4 +339,23 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame('http://imbo/users/christer/images/image?t%5B0%5D=maxSize%3Awidth%3D123%2Cheight%3D123&accessToken=ae738aa84615093e78c635fbbdbef4debb177346a956eb4cefe50bc83592da70', (string) $this->url);
         $this->assertSame((string) $this->url, (string) $this->url);
     }
+
+    /**
+     * @see https://github.com/imbo/imboclient-php/issues/91
+     */
+    public function testUrlsCanBePartiallyConvertedAndUpdated() {
+        $expectedUrl = 'http://imbo/users/christer/images/image.png';
+
+        $this->url->png();
+
+        $this->assertSame($expectedUrl, (string) $this->url);
+        $this->assertSame($expectedUrl, (string) $this->url);
+
+        $this->url->desaturate();
+
+        $expectedUrl .= '?t%5B0%5D=desaturate';
+
+        $this->assertSame($expectedUrl, (string) $this->url);
+        $this->assertSame($expectedUrl, (string) $this->url);
+    }
 }


### PR DESCRIPTION
If a URL has been given an extension, and then converted to a string, the extension will be added again the next time the URL is converted to a string:

``` php
$url = $client->getImageUrl('id');
echo $url->png();
echo $url;
echo $url;
```

will give the following output:

```
http://imbo/users/christer/images/id.png?accessToken=<token>
http://imbo/users/christer/images/id.png.png?accessToken=<token>
http://imbo/users/christer/images/id.png.png.png?accessToken=<token>
```
