### PR TITLE
Use Guzzle\Service\Client as GuzzleClient

### DIFF
--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -12,7 +12,7 @@ namespace ImboClient;
 
 use ImboClient\Http,
     Guzzle\Common\Collection,
-    Guzzle\Service\Client,
+    Guzzle\Service\Client as GuzzleClient,
     Guzzle\Service\Description\ServiceDescription,
     Guzzle\Service\Resource\Model,
     Guzzle\Http\Url as GuzzleUrl,
@@ -27,7 +27,7 @@ use ImboClient\Http,
  * @package Client
  * @author Christer Edvartsen <cogo@starzinger.net>
  */
-class ImboClient extends Client {
+class ImboClient extends GuzzleClient {
     /**
      * URLs to the Imbo server
      *


### PR DESCRIPTION
Use Guzzle\Service\Client as GuzzleClient to prevent name collision:
Fatal error: Cannot use Guzzle\Service\Client as Client because the name is already in use
