### PR TITLE
Fix a bug that caused an error 400 on GenerateShortUrl

### DIFF
--- a/src/ImboClient/EventSubscriber/Authenticate.php
+++ b/src/ImboClient/EventSubscriber/Authenticate.php
@@ -48,6 +48,7 @@ class Authenticate implements EventSubscriberInterface {
             case 'ReplaceMetadata':
             case 'EditMetadata':
             case 'DeleteMetadata':
+            case 'GenerateShortUrl':
                 // Add the auth headers
                 $this->addAuthenticationHeaders($command->getRequest());
                 break;


### PR DESCRIPTION
Because the GenerateShortUrl command wasn’t signed I always got an error 400 (Missing authentication timestamp) when I tried to generate a short URL. To fix this I enabled request signing for GenerateShortUrl.
