### PR TITLE
Imbo 2.0 compatibility

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2011-2014, Christer Edvartsen <cogo@starzinger.net>
+Copyright (c) 2011-2015, Christer Edvartsen <cogo@starzinger.net>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ A PHP client for [Imbo](https://github.com/imbo/imbo).
 [![Current build Status](https://secure.travis-ci.org/imbo/imboclient-php.png)](http://travis-ci.org/imbo/imboclient-php)
 
 ## License
-Copyright (c) 2011-2014, Christer Edvartsen <cogo@starzinger.net>
+Copyright (c) 2011-2015, Christer Edvartsen <cogo@starzinger.net>
 
 Licensed under the MIT License
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,32 +37,32 @@ This can be achieved in two different ways:
 
 .. code-block:: php
 
-    $client = ImboClient\ImboClient::factory(array(
-        'serverUrls' => array('http://imbo.example.com'),
+    $client = ImboClient\ImboClient::factory([
+        'serverUrls' => ['http://imbo.example.com'],
         'publicKey' => 'public key',
         'privateKey' => 'private key',
         'user' => 'username',
-    ));
+    ]);
 
 2) Use the constructor:
 
 .. code-block:: php
 
-    $client = new ImboClient\ImboClient('http://imbo.example.com', array(
+    $client = new ImboClient\ImboClient('http://imbo.example.com', [
         'publicKey' => 'public key',
         'privateKey' => 'private key',
         'user' => 'username',
-    ));
+    ]);
 
 The main difference is that the first argument to the factory method requires you to specify the host name(s) of the Imbo server(s) as an array, while the constructor requires you to pass a string. If you want to use the example number 2 above, and still want to use multiple host names you can use the ``setServerUrls`` method:
 
 .. code-block:: php
 
-    $client->setServerUrls(array(
+    $client->setServerUrls([
         'http//imbo1.example.com',
         'http//imbo2.example.com',
         'http//imbo3.example.com',
-    ));
+    ]);
 
 If you use multiple URLs when instantiating the client it will choose different image URLs based on the image identifier and the number of available host names. If you have a site which includes a lot of ``<img>`` tags against an Imbo server, using multiple hosts might speed up the loading time for your users. If you don't change the amount of server URLs the client will always pick the same host name given the same image identifier.
 
@@ -355,7 +355,7 @@ Here are some examples of how to use the query object:
 
     $current = time();
     $query = new ImboClient\ImagesQuery();
-    $query->limit(10)->from($current - 3600 * 24)->sort(array('size', 'width:desc'));
+    $query->limit(10)->from($current - 3600 * 24)->sort(['size', 'width:desc']);
 
     $collection = $client->getImages($query);
 
@@ -373,7 +373,7 @@ Here are some examples of how to use the query object:
 .. code-block:: php
 
     $query = new ImboClient\ImagesQuery();
-    $query->ids(array('id1', 'id2', 'id3'))->fields(array('width', 'height'));
+    $query->ids(['id1', 'id2', 'id3'])->fields(['width', 'height']);
 
     $collection = $client->getImages($query);
 
@@ -381,8 +381,8 @@ If you want to return metadata, and happen to specify custom fields you will nee
 
 .. code-block:: php
 
-    $query->metadata(true)->fields(array('size')); // Does include the metadata field
-    $query->metadata(true)->fields(array('size', 'metadata')); // Includes the size and metadata fields
+    $query->metadata(true)->fields(['size']); // Does include the metadata field
+    $query->metadata(true)->fields(['size', 'metadata']); // Includes the size and metadata fields
     $query->metadata(true); // Includes all fields, including metadata
     $query->metadata(false); // Exclude the metadata field (default behaviour)
 
@@ -411,10 +411,10 @@ If you have added an image and want to edit its metadata you can use the ``editM
 
 .. code-block:: php
 
-    $metadata = $client->editMetadata('image identifier', array(
+    $metadata = $client->editMetadata('image identifier', [
         'key' => 'value',
         'other key' => 'other value',
-    ));
+    ]);
 
 This method will partially update existing metadata, and the response contains all metadata attached to the image.
 
@@ -425,10 +425,10 @@ If you want to replace all existing metadata with something else you can use the
 
 .. code-block:: php
 
-    $metadata = $client->replaceMetadata('image identifier', array(
+    $metadata = $client->replaceMetadata('image identifier', [
         'key' => 'value',
         'other key' => 'other value',
-    ));
+    ]);
 
 This will first remove existing (if any) metadata, and add the metadata specified as the second parameter. The response contains the metadata of the image, in this case the same as the data being sent to the server.
 
@@ -561,12 +561,12 @@ From version 1.0.0 ImboClient comes with a factory that should be used to instan
 
 .. code-block:: php
 
-    $client = ImboClient\ImboClient::factory(array(
-        'serverUrls' => array('http://imbo.example.com'),
+    $client = ImboClient\ImboClient::factory([
+        'serverUrls' => ['http://imbo.example.com'],
         'publicKey' => 'public key',
         'privateKey' => 'private key',
         'user' => 'username',
-    ));
+    ]);
 
 More examples on how to instantiate the client are available in the :ref:`instantiating-the-client` section.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -460,6 +460,270 @@ To be able to generate short image URLs you can use the ``generateShortUrl`` met
 
 The generated ID can be used with the global short URL resource in Imbo.
 
+Get resource groups
++++++++++++++++++++
+
+To retrieve resource groups available on the Imbo server, you can use the ``getResourceGroups`` method:
+
+.. code-block:: php
+
+    $collection = $client->getResourceGroups();
+
+    echo '<h1>Available resource groups:</h1>';
+    echo '<ul>';
+
+    foreach ($collection['groups'] as $group) {
+        echo '<li>' . $group['name'] . '</li>';
+    }
+
+    echo '</ul>';
+
+The ``$collection`` variable returned from the ``getResourceGroups`` methods has two elements: ``search`` and ``groups``. ``search`` is an array related to pagination and holds information about the groups returned by your query:
+
+``(int) hits``
+    The number of hits from your query.
+
+``(int) page``
+    The current page.
+
+``(int) limit``
+    Limit the number of groups per page.
+
+``(int) count``
+    The number of groups currently on the page.
+
+and the ``groups`` element is a traversable where each element represents a group. Each group is an associative array which includes the following elements:
+
+* ``name`` - name of the group
+* ``resources`` - array of strings defining the resources the group consists of
+
+The ``getResourceGroups`` method can also take a parameter which specifies a query to execute. The parameter is an instance of the ``ImboClient\Query`` class. This class has a set of methods that can be used to customize your query. All methods can be chained when used with a parameter (when setting a value). If you skip the parameter, the methods will return the current value instead:
+
+``page($page = null)``
+    Set or get the ``page`` value. Defaults to ``1``.
+
+``limit($limit = null)``
+    Set or get the ``limit`` value. Defaults to ``20``.
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Get specific resource group
++++++++++++++++++++++++++++
+
+To retrieve a single resource group, you can use the ``getResourceGroup`` method:
+
+.. code-block:: php
+
+    $group = $client->getResourceGroup('group-name');
+
+    echo '<h1>"group-name" consists of the following resources:</h1>';
+    echo '<ul>';
+
+    foreach ($group['resources'] as $resource) {
+        echo '<li>' . $resource . '</li>';
+    }
+
+    echo '</ul>';
+
+The ``$group`` variable returned from the ``getResourceGroup`` method currently only has a single element: ``resources``, which represents the resources the group consists of.
+
+This method will throw an exception if the group name is invalid, already exists or an error occurs.
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Add a resource group
+++++++++++++++++++++
+
+Resource groups can be created using the ``addResourceGroup`` method:
+
+.. code-block:: php
+
+    $client->addResourceGroup('group-name', [
+        'image.get',
+        'image.head',
+        'images.post',
+        'images.get',
+        'images.head'
+    ]);
+
+This method will throw an exception if the group name is invalid, already exists or an error occurs.
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Edit a resource group
++++++++++++++++++++++
+
+Resource groups can be edited using the ``editResourceGroup`` method:
+
+.. code-block:: php
+
+    $client->editResourceGroup('group-name', [
+        'image.get',
+        'image.head',
+        'images.post',
+        'images.get',
+        'images.head'
+    ]);
+
+It's important to note that if the resource group with the given name does not already exist, it will be created. If it exists, the resources provided in the second argument will **overwrite** the existing resources for that group. If you need to add more resources to an existing group, first retrieve it's resources using the ``getResourceGroup``-method and merge the resources returned with the ones you want to add.
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Delete a resource group
++++++++++++++++++++++++
+
+Resource groups can be deleted using the ``deleteResourceGroup`` method:
+
+.. code-block:: php
+
+    $client->deleteResourceGroup('group-name');
+
+.. note:: Any access control rules that are using this resource group will also be deleted, since they are now invalid.
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Check for the existence of a resource group
++++++++++++++++++++++++++++++++++++++++++++
+
+Calling the ``resourceGroupExists`` method will return whether a resource group exists:
+
+.. code-block:: php
+
+    if ($client->resourceGroupExists('group-name')) {
+        echo 'Resource group exists';
+    } else {
+        echo 'Resource group does NOT exist';
+    }
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Creating a new public/private key pair
+++++++++++++++++++++++++++++++++++++++
+
+Adding new public keys (and an associated private key) can be achieved by using the ``addPublicKey`` method:
+
+.. code-block:: php
+
+    $client->addPublicKey('new-pub-key', 'associated-priv-key');
+
+This method will throw an exception if the public key name is invalid, already exists or an error occurs.
+
+.. note:: This function sends the private and public key as plain text to the Imbo server, and should only be used over HTTPS.
+.. note:: Private keys should be hard to guess. We advise you to use a secure password generator to generate one.
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Editing a public/private key pair
++++++++++++++++++++++++++++++++++
+
+Editing existing public/private key pairs can be achieved by using the ``editPublicKey`` method:
+
+.. code-block:: php
+
+    $client->editPublicKey('public-key', 'new-private-key');
+
+This method will throw an exception if the public key name is invalid or an error occurs.
+
+.. note:: All the same considerations should be taken as when using the ``addPublicKey`` method - data is sent in plain text, do not use unless you are communicating over HTTPS!
+
+Deleting a public key
++++++++++++++++++++++
+
+Deleting a public key (and the associated private key) can be achieved by using the ``deletePublicKey`` method:
+
+.. code-block:: php
+
+    $client->deletePublicKey('public-key');
+
+This method will throw an exception if the public key name is invalid or an error occurs.
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Check for the existence of a public key
++++++++++++++++++++++++++++++++++++++++
+
+Calling the ``publicKeyExists`` method will return whether a public key exists:
+
+.. code-block:: php
+
+    if ($client->publicKeyExists('public-key')) {
+        echo 'Public key exists';
+    } else {
+        echo 'Public key does NOT exist';
+    }
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Getting list of ACL-rules for a public key
+++++++++++++++++++++++++++++++++++++++++++
+
+To retrieve a list of the defined access control rules for a given public key, you can use the ``getAccessControlRules`` method:
+
+.. code-block:: php
+
+    $aclRules = $client->getAccessControlRules('public-key');
+
+The return value of this method is a traversable where each element represents a single ACL-rule. See the documentation of ``getAccessControlRule`` below for the details on the contents of these rules.
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+
+Getting a specific ACL-rule for a public key
+++++++++++++++++++++++++++++++++++++++++++++
+
+To retrieve a specific access control rule, you can use the ``getAccessControlRule`` method:
+
+.. code-block:: php
+
+    $aclRule = $client->getAccessControlRule('public-key', 'acl-rule-id');
+
+The return value of this method is a collection (accessible as an array), containing the following keys:
+
+``(string) id``
+    The ID of the ACL-rule (same as the one specified when retrieving the rule).
+
+``(string) group``
+    Name of the resource group which defines which resources this rule should apply for. Only present if ``resources`` is not.
+
+``(array) resources``
+    An array of the resources this ACL-rule grants access to. Only present if ``group`` is not.
+
+``(array|string) users``
+    Either an array of users which this ACL-rule grants access to, or the string ``*``, meaning it gives access to the given resources for **all** users.
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Adding ACL-rules for a public key
++++++++++++++++++++++++++++++++++
+
+To add new access control rules, you can use the ``addAccessControlRules``. It accepts an array of ACL-rules:
+
+.. code-block:: php
+
+    $client->addAccessControlRules('public-key', [
+        [
+            'group' => 'some-group',
+            'users' => ['user1', 'user2']
+        ],
+        [
+            'resources' => ['image.get', 'image.head', 'image.options'],
+            'users' => '*'
+        ]
+    ]);
+
+The ACL-rules you want to create should have the same pattern as documented in ``getAccessControlRule``, expect no ``id`` should be defined.
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
+Deleting an ACL-rule for a public key
++++++++++++++++++++++++++++++++++++++
+
+Deleting an access control rule can be achieve by using the ``deleteAccessControlRule`` method:
+
+.. code-block:: php
+
+    $client->deleteAccessControlRule('public-key', 'acl-rule-id');
+
+.. note:: Not all public keys have (and usually shouldn't have) access to this functionality.
+
 .. _imbo-urls:
 
 Imbo URLs
@@ -497,24 +761,31 @@ All these methods return instances of different classes, and all can be used in 
 The available transformation methods are:
 
 * ``autoRotate()``
+* ``blur($params)``
 * ``border($color = '000000', $width = 1, $height = 1, $mode = 'outbound')``
 * ``canvas($width, $height, $mode = null, $x = null, $y = null, $bg = null)``
 * ``compress($level = 75)``
+* ``contrast($alpha = null, $beta = null)``
 * ``crop($x, $y, $width, $height, $mode)``
 * ``desaturate()``
+* ``drawPois()``
 * ``flipHorizontally()``
 * ``flipVertically()``
 * ``histogram($scale = null, $ratio = null, $red = null, $green = null, $blue = null)``
+* ``level($amount = 1, $channel = null)``
 * ``maxSize($maxWidth = null, $maxHeight = null)``
 * ``modulate($brightness = null, $saturation = null, $hue = null)``
 * ``progressive()``
 * ``resize($width = null, $height = null)``
 * ``rotate($angle, $bg = '000000')``
 * ``sepia($threshold = 80)``
+* ``sharpen($params = null)``
+* ``smartSize($width, $height, $crop = null, $poi = null)``
 * ``strip()``
 * ``thumbnail($width = 50, $height = 50, $fit = 'outbound')``
 * ``transpose()``
 * ``transverse()``
+* ``vignette($scale = null, $outerColor = null, $innerColor = null)``
 * ``watermark($img = null, $width = null, $height = null, $position = 'top-left', $x = 0, $y = 0)``
 
 Please refer to the `server documentation <http://docs.imbo-project.org/>`_ for details about the image transformations.
@@ -548,6 +819,11 @@ There are also some other methods available:
     Removes all transformations added to the URL instance.
 
 The methods related to the image type (``convert`` and the proxy methods) can be added anywhere in the chain. Otherwise all transformations will be applied to the image in the same order as they appear in the chain.
+
+Migrating from ImboClient < 1.3.0
++++++++++++++++++++++++++++++++++
+
+From ImboClient 1.3.0, the client fully supports Imbo 2.0. While the client itself is fully backwards-compatible, we encourage all users to add the ``user`` property when instantiating the client. For users who are still using Imbo 1.x, the user will have the same value as ``publicKey``, while in Imbo 2, these two values can be different.
 
 Migrating from ImboClient < 1.0.0
 +++++++++++++++++++++++++++++++++

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,9 @@ This can be achieved in two different ways:
 
     $client = ImboClient\ImboClient::factory(array(
         'serverUrls' => array('http://imbo.example.com'),
-        'publicKey' => 'user',
+        'publicKey' => 'public key',
         'privateKey' => 'private key',
+        'user' => 'username',
     ));
 
 2) Use the constructor:
@@ -48,8 +49,9 @@ This can be achieved in two different ways:
 .. code-block:: php
 
     $client = new ImboClient\ImboClient('http://imbo.example.com', array(
-        'publicKey' => 'user',
+        'publicKey' => 'public key',
         'privateKey' => 'private key',
+        'user' => 'username',
     ));
 
 The main difference is that the first argument to the factory method requires you to specify the host name(s) of the Imbo server(s) as an array, while the constructor requires you to pass a string. If you want to use the example number 2 above, and still want to use multiple host names you can use the ``setServerUrls`` method:
@@ -104,7 +106,7 @@ If you have access to the server statistics and want to fetch these, you can use
 The return value from this method can be used as an associative array, and includes the following elements:
 
 ``(array) users``
-    An array of users where the keys are user names (public keys) and values are arrays with the following elements:
+    An array of users where the keys are user names and values are arrays with the following elements:
 
     * ``(int) numImages``: Number of images owned by this user
     * ``(int) numBytes``: Number of bytes stored by this user
@@ -130,8 +132,8 @@ Get some information about the user configured with the client:
 
 The value returned from the ``getUserInfo`` method includes the following elements:
 
-``(string) publicKey``
-    The public key of the user (the same as the one used when instantiating the client).
+``(string) user``
+    The user (the same as the one used when instantiating the client).
 
 ``(int) numImages``
     The number of images owned by the user.
@@ -245,7 +247,7 @@ If you want to fetch the number of images owned by the current user you can use 
 
 .. code-block:: php
 
-    echo 'The user "' . $client->getPublicKey() . '" has ' . $client->getNumImages() . ' images.';
+    echo 'The user "' . $client->getUser() . '" has ' . $client->getNumImages() . ' images.';
 
 Get the binary image data
 +++++++++++++++++++++++++
@@ -306,7 +308,7 @@ and the ``images`` element is a traversable where each element represents an ima
 * ``height``
 * ``mime``
 * ``imageIdentifier``
-* ``publicKey``
+* ``user``
 * ``metadata`` (only if the query explicitly enabled metadata in the response, which is off by default).
 
 Some of these elements might not be available if the query excludes some fields (more on that below).
@@ -472,7 +474,7 @@ Imbo uses access tokens in the URLs to prevent `DoS attacks <http://en.wikipedia
     Fetch a URL to the stats endpoint.
 
 ``getUserUrl()``
-    Fetch a URL to the user information of the current user (specified by setting the correct public key when instantiating the client)``.
+    Fetch a URL to the user information of the current user (specified by setting the correct user when instantiating the client)``.
 
 ``getImagesUrl()``
     Fetch a URL to the images endpoint.
@@ -561,8 +563,9 @@ From version 1.0.0 ImboClient comes with a factory that should be used to instan
 
     $client = ImboClient\ImboClient::factory(array(
         'serverUrls' => array('http://imbo.example.com'),
-        'publicKey' => 'user',
+        'publicKey' => 'public key',
         'privateKey' => 'private key',
+        'user' => 'username',
     ));
 
 More examples on how to instantiate the client are available in the :ref:`instantiating-the-client` section.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -4,3 +4,4 @@ metadata
 timestamp
 URL
 accessor
+ACL

--- a/src/ImboClient/EventSubscriber/AccessToken.php
+++ b/src/ImboClient/EventSubscriber/AccessToken.php
@@ -42,6 +42,7 @@ class AccessToken implements EventSubscriberInterface {
         $command = $event['command'];
 
         switch ($command->getName()) {
+            case 'GetGroup':
             case 'GetGroups':
             case 'GetUserInfo':
             case 'GetImages':

--- a/src/ImboClient/EventSubscriber/AccessToken.php
+++ b/src/ImboClient/EventSubscriber/AccessToken.php
@@ -42,6 +42,7 @@ class AccessToken implements EventSubscriberInterface {
         $command = $event['command'];
 
         switch ($command->getName()) {
+            case 'GetGroups':
             case 'GetUserInfo':
             case 'GetImages':
             case 'GetImageProperties':

--- a/src/ImboClient/EventSubscriber/AccessToken.php
+++ b/src/ImboClient/EventSubscriber/AccessToken.php
@@ -42,8 +42,10 @@ class AccessToken implements EventSubscriberInterface {
         $command = $event['command'];
 
         switch ($command->getName()) {
-            case 'GetGroup':
-            case 'GetGroups':
+            case 'GetResourceGroup':
+            case 'GetResourceGroups':
+            case 'GetAccessControlRule':
+            case 'GetAccessControlRules':
             case 'GetUserInfo':
             case 'GetImages':
             case 'GetImageProperties':

--- a/src/ImboClient/EventSubscriber/Authenticate.php
+++ b/src/ImboClient/EventSubscriber/Authenticate.php
@@ -54,6 +54,7 @@ class Authenticate implements EventSubscriberInterface {
             case 'EditPublicKey':
             case 'DeletePublicKey':
             case 'AddAccessControlRules':
+            case 'DeleteAccessControlRule':
                 // Add the auth headers
                 $this->addAuthenticationHeaders($command->getRequest());
                 break;

--- a/src/ImboClient/EventSubscriber/Authenticate.php
+++ b/src/ImboClient/EventSubscriber/Authenticate.php
@@ -50,6 +50,7 @@ class Authenticate implements EventSubscriberInterface {
             case 'DeleteMetadata':
             case 'GenerateShortUrl':
             case 'EditGroup':
+            case 'DeleteGroup':
                 // Add the auth headers
                 $this->addAuthenticationHeaders($command->getRequest());
                 break;

--- a/src/ImboClient/EventSubscriber/Authenticate.php
+++ b/src/ImboClient/EventSubscriber/Authenticate.php
@@ -51,6 +51,7 @@ class Authenticate implements EventSubscriberInterface {
             case 'GenerateShortUrl':
             case 'EditGroup':
             case 'DeleteGroup':
+            case 'EditPublicKey':
                 // Add the auth headers
                 $this->addAuthenticationHeaders($command->getRequest());
                 break;

--- a/src/ImboClient/EventSubscriber/Authenticate.php
+++ b/src/ImboClient/EventSubscriber/Authenticate.php
@@ -52,6 +52,7 @@ class Authenticate implements EventSubscriberInterface {
             case 'EditGroup':
             case 'DeleteGroup':
             case 'EditPublicKey':
+            case 'DeletePublicKey':
                 // Add the auth headers
                 $this->addAuthenticationHeaders($command->getRequest());
                 break;

--- a/src/ImboClient/EventSubscriber/Authenticate.php
+++ b/src/ImboClient/EventSubscriber/Authenticate.php
@@ -53,6 +53,7 @@ class Authenticate implements EventSubscriberInterface {
             case 'DeleteGroup':
             case 'EditPublicKey':
             case 'DeletePublicKey':
+            case 'AddAccessControlRules':
                 // Add the auth headers
                 $this->addAuthenticationHeaders($command->getRequest());
                 break;

--- a/src/ImboClient/EventSubscriber/Authenticate.php
+++ b/src/ImboClient/EventSubscriber/Authenticate.php
@@ -49,6 +49,7 @@ class Authenticate implements EventSubscriberInterface {
             case 'EditMetadata':
             case 'DeleteMetadata':
             case 'GenerateShortUrl':
+            case 'EditGroup':
                 // Add the auth headers
                 $this->addAuthenticationHeaders($command->getRequest());
                 break;

--- a/src/ImboClient/EventSubscriber/Authenticate.php
+++ b/src/ImboClient/EventSubscriber/Authenticate.php
@@ -49,8 +49,8 @@ class Authenticate implements EventSubscriberInterface {
             case 'EditMetadata':
             case 'DeleteMetadata':
             case 'GenerateShortUrl':
-            case 'EditGroup':
-            case 'DeleteGroup':
+            case 'EditResourceGroup':
+            case 'DeleteResourceGroup':
             case 'EditPublicKey':
             case 'DeletePublicKey':
             case 'AddAccessControlRules':

--- a/src/ImboClient/EventSubscriber/PublicKey.php
+++ b/src/ImboClient/EventSubscriber/PublicKey.php
@@ -42,7 +42,6 @@ class PublicKey implements EventSubscriberInterface {
     public function addPublicKey(Event $event) {
         $command = $event['command'];
         $request = $command->getRequest();
-        $client = $request->getClient();
         $url = $request->getUrl(true);
 
         // Don't add public key if query string already contains public key
@@ -50,6 +49,7 @@ class PublicKey implements EventSubscriberInterface {
             return;
         }
 
+        $client = $request->getClient();
         $publicKey = $client->getPublicKey();
         $user = $client->getUser();
 

--- a/src/ImboClient/EventSubscriber/PublicKey.php
+++ b/src/ImboClient/EventSubscriber/PublicKey.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClient\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface,
+    Guzzle\Common\Event;
+
+/**
+ * Public key event subscriber
+ *
+ * This subscriber is used to append a public key query parameter to URL's when the
+ * public key and current user does not match
+ *
+ * @package Client\Event subscribers
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ */
+class PublicKey implements EventSubscriberInterface {
+    /**
+     * Get events this subscriber subscribes to
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents() {
+        return array(
+            'command.before_send' => array('appendPublicKey', -500),
+        );
+    }
+
+    /**
+     * Append a public key query parameter to the request URL
+     *
+     * @param Event $event The current event
+     */
+    public function appendPublicKey(Event $event) {
+        $command = $event['command'];
+        $request = $command->getRequest();
+        $client = $request->getClient();
+        $publicKey = $client->getPublicKey();
+        $user = $client->getUser();
+
+        // No need for the query parameter if the user and public key matches
+        if ($user === $publicKey) {
+            return;
+        }
+
+        switch ($command->getName()) {
+            case 'AddImage':
+            case 'DeleteImage':
+            case 'DeleteMetadata':
+            case 'EditMetadata':
+            case 'GenerateShortUrl':
+            case 'GetImageProperties':
+            case 'GetImages':
+            case 'GetMetadata':
+            case 'GetUserInfo':
+            case 'ReplaceMetadata':
+                // Add as query parameter
+                $request->getQuery()->set('publicKey', $publicKey);
+                break;
+        }
+    }
+}

--- a/src/ImboClient/EventSubscriber/PublicKey.php
+++ b/src/ImboClient/EventSubscriber/PublicKey.php
@@ -30,41 +30,28 @@ class PublicKey implements EventSubscriberInterface {
      */
     public static function getSubscribedEvents() {
         return array(
-            'command.before_send' => array('appendPublicKey', -500),
+            'command.before_send' => array('addPublicKey', -500),
         );
     }
 
     /**
-     * Append a public key query parameter to the request URL
+     * Add a public key header to the request
      *
      * @param Event $event The current event
      */
-    public function appendPublicKey(Event $event) {
+    public function addPublicKey(Event $event) {
         $command = $event['command'];
         $request = $command->getRequest();
         $client = $request->getClient();
+
         $publicKey = $client->getPublicKey();
         $user = $client->getUser();
 
         // No need for the query parameter if the user and public key matches
-        if ($user === $publicKey) {
+        if ($user && $user === $publicKey) {
             return;
         }
 
-        switch ($command->getName()) {
-            case 'AddImage':
-            case 'DeleteImage':
-            case 'DeleteMetadata':
-            case 'EditMetadata':
-            case 'GenerateShortUrl':
-            case 'GetImageProperties':
-            case 'GetImages':
-            case 'GetMetadata':
-            case 'GetUserInfo':
-            case 'ReplaceMetadata':
-                // Add as query parameter
-                $request->getQuery()->set('publicKey', $publicKey);
-                break;
-        }
+        $request->setHeader('X-Imbo-PublicKey', $publicKey);
     }
 }

--- a/src/ImboClient/EventSubscriber/PublicKey.php
+++ b/src/ImboClient/EventSubscriber/PublicKey.php
@@ -43,11 +43,17 @@ class PublicKey implements EventSubscriberInterface {
         $command = $event['command'];
         $request = $command->getRequest();
         $client = $request->getClient();
+        $url = $request->getUrl(true);
+
+        // Don't add public key if query string already contains public key
+        if ($url->getQuery()->hasKey('publicKey')) {
+            return;
+        }
 
         $publicKey = $client->getPublicKey();
         $user = $client->getUser();
 
-        // No need for the query parameter if the user and public key matches
+        // No need for the header if the user and public key matches
         if ($user && $user === $publicKey) {
             return;
         }

--- a/src/ImboClient/Helper/PublicKeyFallback.php
+++ b/src/ImboClient/Helper/PublicKeyFallback.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClient\Helper;
+
+/**
+ * Public key fallback helper. Used to translate between user and public keys,
+ * which changed meaning in Imbo 2.0.
+ *
+ * @package Client\Helper
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ */
+class PublicKeyFallback {
+    /**
+     * For backwards-compatibility, we provide both `user` and `publicKey`.
+     * In future version of ImboClient, the `publicKey` will be removed.
+     *
+     * @param array $info
+     * @return array
+     */
+    public static function fallback($info) {
+        $user = isset($info['user']) ? $info['user'] : null;
+        $publicKey = isset($info['publicKey']) ? $info['publicKey'] : null;
+
+        if (!$user && $publicKey) {
+            $info['user'] = $publicKey;
+        } else if (!$publicKey && $user) {
+            $info['publicKey'] = $user;
+        }
+
+        return $info;
+    }
+}

--- a/src/ImboClient/Http/GroupUrl.php
+++ b/src/ImboClient/Http/GroupUrl.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClient\Http;
+
+/**
+ * Group URL
+ *
+ * @package Client\Urls
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ */
+class GroupUrl extends Url {
+    /**
+     * Get the group part of a URL
+     *
+     * @return string|null
+     */
+    public function getGroup() {
+        if (preg_match('#/groups/(?<group>[^./]+)#', $this->getPath(), $match)) {
+            return $match['group'];
+        }
+
+        return null;
+    }
+}

--- a/src/ImboClient/Http/GroupsUrl.php
+++ b/src/ImboClient/Http/GroupsUrl.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClient\Http;
+
+/**
+ * Groups URL
+ *
+ * @package Client\Urls
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ */
+class GroupsUrl extends Url {}

--- a/src/ImboClient/Http/KeyUrl.php
+++ b/src/ImboClient/Http/KeyUrl.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClient\Http;
+
+/**
+ * Key URL
+ *
+ * @package Client\Urls
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ */
+class KeyUrl extends Url {
+    /**
+     * Get the key part of a URL
+     *
+     * @return string|null
+     */
+    public function getKey() {
+        if (preg_match('#/keys/(?<key>[^./]+)#', $this->getPath(), $match)) {
+            return $match['key'];
+        }
+
+        return null;
+    }
+}

--- a/src/ImboClient/Http/KeysUrl.php
+++ b/src/ImboClient/Http/KeysUrl.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClient\Http;
+
+/**
+ * Keys URL
+ *
+ * @package Client\Urls
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ */
+class KeysUrl extends Url {}

--- a/src/ImboClient/Http/ResourceGroupUrl.php
+++ b/src/ImboClient/Http/ResourceGroupUrl.php
@@ -11,12 +11,12 @@
 namespace ImboClient\Http;
 
 /**
- * Group URL
+ * Resource group URL
  *
  * @package Client\Urls
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  */
-class GroupUrl extends Url {
+class ResourceGroupUrl extends Url {
     /**
      * Get the group part of a URL
      *

--- a/src/ImboClient/Http/ResourceGroupsUrl.php
+++ b/src/ImboClient/Http/ResourceGroupsUrl.php
@@ -11,9 +11,9 @@
 namespace ImboClient\Http;
 
 /**
- * Groups URL
+ * Resource groups URL
  *
  * @package Client\Urls
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  */
-class GroupsUrl extends Url {}
+class ResourceGroupsUrl extends Url {}

--- a/src/ImboClient/Http/Url.php
+++ b/src/ImboClient/Http/Url.php
@@ -31,16 +31,35 @@ class Url extends GuzzleUrl {
      *
      * @param string $url URL as a string
      * @param string $privateKey Optional private key
+     * @param string $publicKey Optional public key
      * @return Url
      */
-    public static function factory($url, $privateKey = null) {
+    public static function factory($url, $privateKey = null, $publicKey = null) {
         $url = parent::factory($url);
+        $user = self::getUserFromUrl($url->getPath());
 
         if ($privateKey) {
             $url->setPrivateKey($privateKey);
         }
 
+        if ($publicKey && $user !== $publicKey) {
+            $url->getQuery()->set('publicKey', $publicKey);
+        }
+
         return $url;
+    }
+
+    /**
+     * Get the user part of a given URL
+     *
+     * @return string|null
+     */
+    public function getUserFromUrl($url) {
+        if (preg_match('#/users/(?<user>[^./]+)#', $url, $match)) {
+            return $match['user'];
+        }
+
+        return null;
     }
 
     /**
@@ -78,11 +97,7 @@ class Url extends GuzzleUrl {
      * @return string|null
      */
     public function getUser() {
-        if (preg_match('#/users/(?<user>[^./]+)#', $this->getPath(), $match)) {
-            return $match['user'];
-        }
-
-        return null;
+        return self::getUserFromUrl($this->getPath());
     }
 
     /**

--- a/src/ImboClient/Http/Url.php
+++ b/src/ImboClient/Http/Url.php
@@ -64,6 +64,28 @@ class Url extends GuzzleUrl {
     }
 
     /**
+     * Get the public key part of a URL
+     *
+     * @return string|null
+     */
+    public function getPublicKey() {
+        return $this->getQuery()->get('publicKey') ?: $this->getUser();
+    }
+
+    /**
+     * Get the user part of a URL
+     *
+     * @return string|null
+     */
+    public function getUser() {
+        if (preg_match('#/users/(?<user>[^./]+)#', $this->getPath(), $match)) {
+            return $match['user'];
+        }
+
+        return null;
+    }
+
+    /**
      * Set the private key
      *
      * @param string $privateKey The private key to use when appending access tokens to the URL's

--- a/src/ImboClient/Http/Url.php
+++ b/src/ImboClient/Http/Url.php
@@ -66,7 +66,7 @@ class Url extends GuzzleUrl {
      *
      * @return string|null
      */
-    public function getUserFromUrl($url) {
+    public static function getUserFromUrl($url) {
         if (preg_match('#/users/(?<user>[^./]+)#', $url, $match)) {
             return $match['user'];
         }

--- a/src/ImboClient/Http/UserUrl.php
+++ b/src/ImboClient/Http/UserUrl.php
@@ -16,17 +16,4 @@ namespace ImboClient\Http;
  * @package Client\Urls
  * @author Christer Edvartsen <cogo@starzinger.net>
  */
-class UserUrl extends Url {
-    /**
-     * Get the public key part of a URL
-     *
-     * @return string|null
-     */
-    public function getPublicKey() {
-        if (preg_match('#/users/(?<publicKey>[^./]+)#', $this->getPath(), $match)) {
-            return $match['publicKey'];
-        }
-
-        return null;
-    }
-}
+class UserUrl extends Url {}

--- a/src/ImboClient/ImagesQuery.php
+++ b/src/ImboClient/ImagesQuery.php
@@ -16,108 +16,62 @@ namespace ImboClient;
  * @package Client
  * @author Christer Edvartsen <cogo@starzinger.net>
  */
-class ImagesQuery {
-    /**
-     * The page to get
-     *
-     * @var int
-     */
-    private $page = 1;
-
-    /**
-     * Number of images to get
-     *
-     * @var int
-     */
-    private $limit = 20;
-
+class ImagesQuery extends Query {
     /**
      * Return metadata or not
      *
      * @var boolean
      */
-    private $metadata = false;
+    protected $metadata = false;
 
     /**
      * Unix timestamp to start fetching from
      *
      * @var int
      */
-    private $from;
+    protected $from;
 
     /**
      * Unix timestamp to fetch until
      *
      * @var int
      */
-    private $to;
+    protected $to;
 
     /**
      * List of fields to include in the response
      *
      * @var string[]
      */
-    private $fields = array();
+    protected $fields = array();
 
     /**
      * List of fields to sort by
      *
      * @var string[]
      */
-    private $sort = array();
+    protected $sort = array();
 
     /**
      * Filter on these ID's
      *
      * @var string[]
      */
-    private $ids = array();
+    protected $ids = array();
 
     /**
      * Filter on these checksums
      *
      * @var string[]
      */
-    private $checksums = array();
+    protected $checksums = array();
 
     /**
      * Filter on these original checksums
      *
      * @var string[]
      */
-    private $originalChecksums = array();
-
-    /**
-     * Set or get the page property
-     *
-     * @param int $page Give this a value to set the page property
-     * @return int|self
-     */
-    public function page($page = null) {
-        if ($page === null) {
-            return $this->page;
-        }
-
-        $this->page = (int) $page;
-
-        return $this;
-    }
-
-    /**
-     * Set or get the limit property
-     *
-     * @param int $limit Give this a value to set the limit property
-     * @return int|self
-     */
-    public function limit($limit = null) {
-        if ($limit === null) {
-            return $this->limit;
-        }
-
-        $this->limit = (int) $limit;
-
-        return $this;
-    }
+    protected $originalChecksums = array();
 
     /**
      * Set or get the metadata flag

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -454,6 +454,29 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Checks if a given group exists on the server already
+     *
+     * @param string $groupName Name of the group
+     * @throws InvalidArgumentException Throws an exception if group name is invalid
+     * @return boolean
+     */
+    public function groupExists($groupName) {
+        $this->validateGroupName($groupName);
+
+        try {
+            $response = $this->head((string) $this->getGroupUrl($groupName))->send();
+
+            return $response->getStatusCode() === 200;
+        } catch (GuzzleException $e) {
+            if ($e->getResponse()->getStatusCode() === 404) {
+                return false;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
      * Get all server URL's
      *
      * @return string[]
@@ -487,6 +510,21 @@ class ImboClient extends GuzzleClient {
      */
     public function getGroupsUrl() {
         return Http\GroupsUrl::factory($this->getBaseUrl() . '/groups.json');
+    }
+
+    /**
+     * Get a URL for the group endpoint
+     *
+     * @param string $groupName Name of group
+     * @return Http\GroupUrl
+     */
+    public function getGroupUrl($groupName) {
+        $url = sprintf(
+            $this->getBaseUrl() . '/groups/%s.json',
+            $groupName
+        );
+
+        return Http\GroupUrl::factory($url, $this->getConfig('privateKey'));
     }
 
     /**

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -442,7 +442,7 @@ class ImboClient extends GuzzleClient {
      *
      * @param string $groupName Name of group to get
      * @return Model
-     * @throws InvalidArgumentException If the group name is not valid
+     * @throws InvalidArgumentException If the group name is invalid
      */
     public function getGroup($groupName) {
         $this->validateGroupName($groupName);
@@ -526,6 +526,7 @@ class ImboClient extends GuzzleClient {
      * @param string $publicKey Public key to create
      * @param string $privateKey Private key for the new public key
      * @return Model
+     * @throws InvalidArgumentException If the public key name is invalid
      */
     public function addPublicKey($publicKey, $privateKey) {
         $this->validatePublicKeyName($publicKey);
@@ -549,6 +550,7 @@ class ImboClient extends GuzzleClient {
      * @param string $publicKey Public key to alter private key for
      * @param string $privateKey New private key to use for the given public key
      * @return Model
+     * @throws InvalidArgumentException If the public key name is invalid
      */
     public function editPublicKey($publicKey, $privateKey) {
         $this->validatePublicKeyName($publicKey);
@@ -566,6 +568,7 @@ class ImboClient extends GuzzleClient {
      * @param  string $publicKey Name of the public key to delete
      * @return Model
      * @throws InvalidArgumentException Thrown when the public key name is invalid
+     * @throws InvalidArgumentException If the public key name is invalid
      */
     public function deletePublicKey($publicKey) {
         $this->validatePublicKeyName($publicKey);
@@ -581,6 +584,7 @@ class ImboClient extends GuzzleClient {
      *
      * @param string $publicKey Public key
      * @return boolean
+     * @throws InvalidArgumentException If the public key name is invalid
      */
     public function publicKeyExists($publicKey) {
         $this->validatePublicKeyName($publicKey);
@@ -593,6 +597,7 @@ class ImboClient extends GuzzleClient {
      *
      * @param string $publicKey Public key
      * @return Model
+     * @throws InvalidArgumentException If the public key name is invalid
      */
     public function getAccessControlRules($publicKey) {
         $this->validatePublicKeyName($publicKey);
@@ -609,6 +614,7 @@ class ImboClient extends GuzzleClient {
      * @param string $publicKey Public key
      * @param string $ruleId ID of the rule to retrieve
      * @return Model
+     * @throws InvalidArgumentException If the public key name is invalid
      */
     public function getAccessControlRule($publicKey, $ruleId) {
         $this->validatePublicKeyName($publicKey);
@@ -617,6 +623,36 @@ class ImboClient extends GuzzleClient {
             'signaturePublicKey' => $this->getPublicKey(),
             'publicKey' => $publicKey,
             'id' => $ruleId,
+        ))->execute();
+    }
+
+    /**
+     * Add access control rule to the given public key
+     *
+     * @param string $publicKey Public key to add rule to
+     * @param array $rule Rule to add
+     * @return Model
+     * @throws InvalidArgumentException If the public key name is invalid
+     */
+    public function addAccessControlRule($publicKey, $rule) {
+        return $this->addAccessControlRules($publicKey, array($rule));
+    }
+
+    /**
+     * Add access control rules to the given public key
+     *
+     * @param string $publicKey Public key to add rules to
+     * @param array $rules Rules to add
+     * @return Model
+     * @throws InvalidArgumentException If the public key name is invalid
+     */
+    public function addAccessControlRules($publicKey, $rules) {
+        $this->validatePublicKeyName($publicKey);
+
+        return $this->getCommand('AddAccessControlRules', array(
+            'signaturePublicKey' => $this->getPublicKey(),
+            'publicKey' => $publicKey,
+            'rules' => json_encode($rules),
         ))->execute();
     }
 

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -442,8 +442,11 @@ class ImboClient extends GuzzleClient {
      *
      * @param string $groupName Name of group to get
      * @return Model
+     * @throws InvalidArgumentException If the group name is not valid
      */
     public function getGroup($groupName) {
+        $this->validateGroupName($groupName);
+
         return $this->getCommand('GetGroup', array(
             'publicKey' => $this->getPublicKey(),
             'groupName' => $groupName,
@@ -719,6 +722,20 @@ class ImboClient extends GuzzleClient {
 
         if (!filesize($path)) {
             throw new InvalidArgumentException('File is of zero length: ' . $path);
+        }
+    }
+
+    /**
+     * Helper method to make sure a grou name is valid
+     *
+     * @param string $name The name of the group
+     * @throws InvalidArgumentException
+     */
+    private function validateGroupName($name) {
+        if (!preg_match('/^[a-z0-9_-]{1,}$/', $name)) {
+            throw new InvalidArgumentException(
+                'Group name can only consist of: a-z, 0-9 and the characters _ and -'
+            );
         }
     }
 }

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -600,7 +600,13 @@ class ImboClient extends GuzzleClient {
      * @return string
      */
     private function getHostForImageIdentifier($imageIdentifier) {
-        $dec = hexdec($imageIdentifier[0] . $imageIdentifier[1]);
+        $dec = ord(substr($imageIdentifier, -1));
+
+        // If this is an old image identifier (32 character hex string),
+        // maintain backwards compatibility
+        if (preg_match('#^[a-f0-9]{32}$#', $imageIdentifier)) {
+            $dec = hexdec($imageIdentifier[0] . $imageIdentifier[1]);
+        }
 
         return $this->serverUrls[$dec % count($this->serverUrls)];
     }

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -521,12 +521,31 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Edit a public/private key pair
+     *
+     * @param string $publicKey Public key to alter private key for
+     * @param string $privateKey New private key to use for the given public key
+     * @return Model
+     */
+    public function editPublicKey($publicKey, $privateKey) {
+        $this->validatePublicKeyName($publicKey);
+
+        return $this->getCommand('EditPublicKey', array(
+            'signaturePublicKey' => $this->getPublicKey(),
+            'properties' => json_encode(array('privateKey' => $privateKey)),
+            'publicKey' => $publicKey,
+        ))->execute();
+    }
+
+    /**
      * Checks if a given public key exists on the server already
      *
      * @param string $publicKey Public key
      * @return boolean
      */
     public function publicKeyExists($publicKey) {
+        $this->validatePublicKeyName($publicKey);
+
         return $this->resourceExists($this->getKeyUrl($publicKey));
     }
 
@@ -838,15 +857,26 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
-     * Helper method to make sure a grou name is valid
+     * Helper method to make sure a public key is valid
      *
-     * @param string $name The name of the group
+     * @param string $name Public key name
      * @throws InvalidArgumentException
      */
-    private function validateGroupName($name) {
+    private function validatePublicKeyName($name) {
+        return $this->validateGroupName($name, 'Public key');
+    }
+
+    /**
+     * Helper method to make sure a group name is valid
+     *
+     * @param string $name The name of the group
+     * @param string $entity Entity we're validating
+     * @throws InvalidArgumentException
+     */
+    private function validateGroupName($name, $entity = 'Group name') {
         if (!preg_match('/^[a-z0-9_-]{1,}$/', $name)) {
             throw new InvalidArgumentException(
-                'Group name can only consist of: a-z, 0-9 and the characters _ and -'
+                $entity . ' can only consist of: a-z, 0-9 and the characters _ and -'
             );
         }
     }

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -425,13 +425,12 @@ class ImboClient extends GuzzleClient {
      * @param Query $query An optional query object
      * @return Model
      */
-    public function getGroups(Query $query = null) {
+    public function getResourceGroups(Query $query = null) {
         if (!$query) {
             $query = new Query();
         }
 
-        return $this->getCommand('GetGroups', array(
-            'publicKey' => $this->getPublicKey(),
+        return $this->getCommand('GetResourceGroups', array(
             'page' => $query->page(),
             'limit' => $query->limit(),
         ))->execute();
@@ -444,11 +443,10 @@ class ImboClient extends GuzzleClient {
      * @return Model
      * @throws InvalidArgumentException If the group name is invalid
      */
-    public function getGroup($groupName) {
-        $this->validateGroupName($groupName);
+    public function getResourceGroup($groupName) {
+        $this->validateResourceGroupName($groupName);
 
-        return $this->getCommand('GetGroup', array(
-            'publicKey' => $this->getPublicKey(),
+        return $this->getCommand('GetResourceGroup', array(
             'groupName' => $groupName,
         ))->execute();
     }
@@ -461,31 +459,32 @@ class ImboClient extends GuzzleClient {
      * @return Model
      * @throws InvalidArgumentException Throw when group name is invalid or group already exists
      */
-    public function addGroup($groupName, array $resources) {
-        $this->validateGroupName($groupName);
+    public function addResourceGroup($groupName, array $resources) {
+        $this->validateResourceGroupName($groupName);
 
-        if ($this->groupExists($groupName)) {
+        if ($this->resourceGroupExists($groupName)) {
             throw new InvalidArgumentException(
-                'Group with name "' . $groupName . '" already exists'
+                'Resource group with name "' . $groupName . '" already exists'
             );
         }
 
-        return $this->editGroup($groupName, $resources);
+        return $this->editResourceGroup($groupName, $resources);
     }
 
     /**
      * Edit a resource group
+     *
+     * Note: If the resource group does not already exist, it will be created
      *
      * @param string $groupName Name of the group to edit
      * @param array $resources Array of resource names the group should contain
      * @return Model
      * @throws InvalidArgumentException Thrown when group name is invalid or group already exists
      */
-    public function editGroup($groupName, array $resources) {
-        $this->validateGroupName($groupName);
+    public function editResourceGroup($groupName, array $resources) {
+        $this->validateResourceGroupName($groupName);
 
-        return $this->getCommand('EditGroup', array(
-            'publicKey' => $this->getPublicKey(),
+        return $this->getCommand('EditResourceGroup', array(
             'groupName' => $groupName,
             'resources' => json_encode($resources),
         ))->execute();
@@ -498,11 +497,10 @@ class ImboClient extends GuzzleClient {
      * @return Model
      * @throws InvalidArgumentException Thrown when the group name is invalid or does not exist
      */
-    public function deleteGroup($groupName) {
-        $this->validateGroupName($groupName);
+    public function deleteResourceGroup($groupName) {
+        $this->validateResourceGroupName($groupName);
 
-        return $this->getCommand('DeleteGroup', array(
-            'publicKey' => $this->getPublicKey(),
+        return $this->getCommand('DeleteResourceGroup', array(
             'groupName' => $groupName,
         ))->execute();
     }
@@ -514,10 +512,10 @@ class ImboClient extends GuzzleClient {
      * @throws InvalidArgumentException Throws an exception if group name is invalid
      * @return boolean
      */
-    public function groupExists($groupName) {
-        $this->validateGroupName($groupName);
+    public function resourceGroupExists($groupName) {
+        $this->validateResourceGroupName($groupName);
 
-        return $this->resourceExists($this->getGroupUrl($groupName));
+        return $this->resourceExists($this->getResourceGroupUrl($groupName));
     }
 
     /**
@@ -538,7 +536,6 @@ class ImboClient extends GuzzleClient {
         }
 
         return $this->getCommand('EditPublicKey', array(
-            'signaturePublicKey' => $this->getPublicKey(),
             'properties' => json_encode(array('privateKey' => $privateKey)),
             'publicKey' => $publicKey,
         ))->execute();
@@ -556,7 +553,6 @@ class ImboClient extends GuzzleClient {
         $this->validatePublicKeyName($publicKey);
 
         return $this->getCommand('EditPublicKey', array(
-            'signaturePublicKey' => $this->getPublicKey(),
             'properties' => json_encode(array('privateKey' => $privateKey)),
             'publicKey' => $publicKey,
         ))->execute();
@@ -573,7 +569,6 @@ class ImboClient extends GuzzleClient {
         $this->validatePublicKeyName($publicKey);
 
         return $this->getCommand('DeletePublicKey', array(
-            'signaturePublicKey' => $this->getPublicKey(),
             'publicKey' => $publicKey,
         ))->execute();
     }
@@ -602,7 +597,6 @@ class ImboClient extends GuzzleClient {
         $this->validatePublicKeyName($publicKey);
 
         return $this->getCommand('GetAccessControlRules', array(
-            'signaturePublicKey' => $this->getPublicKey(),
             'publicKey' => $publicKey,
         ))->execute();
     }
@@ -619,7 +613,6 @@ class ImboClient extends GuzzleClient {
         $this->validatePublicKeyName($publicKey);
 
         return $this->getCommand('GetAccessControlRule', array(
-            'signaturePublicKey' => $this->getPublicKey(),
             'publicKey' => $publicKey,
             'id' => $ruleId,
         ))->execute();
@@ -649,7 +642,6 @@ class ImboClient extends GuzzleClient {
         $this->validatePublicKeyName($publicKey);
 
         return $this->getCommand('AddAccessControlRules', array(
-            'signaturePublicKey' => $this->getPublicKey(),
             'publicKey' => $publicKey,
             'rules' => json_encode($rules),
         ))->execute();
@@ -667,7 +659,6 @@ class ImboClient extends GuzzleClient {
         $this->validatePublicKeyName($publicKey);
 
         return $this->getCommand('DeleteAccessControlRule', array(
-            'signaturePublicKey' => $this->getPublicKey(),
             'publicKey' => $publicKey,
             'id' => $ruleId,
         ))->execute();
@@ -705,8 +696,8 @@ class ImboClient extends GuzzleClient {
      *
      * @return Http\GroupsUrl
      */
-    public function getGroupsUrl() {
-        return Http\GroupsUrl::factory(
+    public function getResourceGroupsUrl() {
+        return Http\ResourceGroupsUrl::factory(
             $this->getBaseUrl() . '/groups.json',
             $this->getConfig('privateKey')
         );
@@ -718,13 +709,13 @@ class ImboClient extends GuzzleClient {
      * @param string $groupName Name of group
      * @return Http\GroupUrl
      */
-    public function getGroupUrl($groupName) {
+    public function getResourceGroupUrl($groupName) {
         $url = sprintf(
             $this->getBaseUrl() . '/groups/%s.json',
             $groupName
         );
 
-        return Http\GroupUrl::factory($url, $this->getConfig('privateKey'));
+        return Http\ResourceGroupUrl::factory($url, $this->getConfig('privateKey'));
     }
 
     /**
@@ -987,7 +978,7 @@ class ImboClient extends GuzzleClient {
      * @throws InvalidArgumentException
      */
     private function validatePublicKeyName($name) {
-        return $this->validateGroupName($name, 'Public key');
+        return $this->validateResourceGroupName($name, 'Public key');
     }
 
     /**
@@ -997,7 +988,7 @@ class ImboClient extends GuzzleClient {
      * @param string $entity Entity we're validating
      * @throws InvalidArgumentException
      */
-    private function validateGroupName($name, $entity = 'Group name') {
+    private function validateResourceGroupName($name, $entity = 'Group name') {
         if (!preg_match('/^[a-z0-9_-]{1,}$/', $name)) {
             throw new InvalidArgumentException(
                 $entity . ' can only consist of: a-z, 0-9 and the characters _ and -'

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -470,6 +470,20 @@ class ImboClient extends GuzzleClient {
             );
         }
 
+        return $this->editGroup($groupName, $resources);
+    }
+
+    /**
+     * Edit a resource group
+     *
+     * @param string $groupName Name of the group to edit
+     * @param array $resources Array of resource names the group should contain
+     * @return Model
+     * @throws InvalidArgumentException Throw when group name is invalid or group already exists
+     */
+    public function editGroup($groupName, array $resources) {
+        $this->validateGroupName($groupName);
+
         return $this->getCommand('EditGroup', array(
             'publicKey' => $this->getPublicKey(),
             'groupName' => $groupName,

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -604,6 +604,23 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Get the access control rule with the given ID which belongs to the given public key
+     *
+     * @param string $publicKey Public key
+     * @param string $ruleId ID of the rule to retrieve
+     * @return Model
+     */
+    public function getAccessControlRule($publicKey, $ruleId) {
+        $this->validatePublicKeyName($publicKey);
+
+        return $this->getCommand('GetAccessControlRule', array(
+            'signaturePublicKey' => $this->getPublicKey(),
+            'publicKey' => $publicKey,
+            'id' => $ruleId,
+        ))->execute();
+    }
+
+    /**
      * Get all server URL's
      *
      * @return string[]

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -454,6 +454,30 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Add a new resource group
+     *
+     * @param string $groupName Name of the group to create
+     * @param array $resources Array of resource names the group should contain
+     * @return Model
+     * @throws InvalidArgumentException Throw when group name is invalid or group already exists
+     */
+    public function addGroup($groupName, array $resources) {
+        $this->validateGroupName($groupName);
+
+        if ($this->groupExists($groupName)) {
+            throw new InvalidArgumentException(
+                'Group with name "' . $groupName . '" already exists'
+            );
+        }
+
+        return $this->getCommand('EditGroup', array(
+            'publicKey' => $this->getPublicKey(),
+            'groupName' => $groupName,
+            'resources' => json_encode($resources),
+        ))->execute();
+    }
+
+    /**
      * Checks if a given group exists on the server already
      *
      * @param string $groupName Name of the group

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -589,6 +589,21 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Get access control rules for the given public key
+     *
+     * @param string $publicKey Public key
+     * @return Model
+     */
+    public function getAccessControlRules($publicKey) {
+        $this->validatePublicKeyName($publicKey);
+
+        return $this->getCommand('GetAccessControlRules', array(
+            'signaturePublicKey' => $this->getPublicKey(),
+            'publicKey' => $publicKey,
+        ))->execute();
+    }
+
+    /**
      * Get all server URL's
      *
      * @return string[]

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -561,6 +561,22 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Delete a public key
+     *
+     * @param  string $publicKey Name of the public key to delete
+     * @return Model
+     * @throws InvalidArgumentException Thrown when the public key name is invalid
+     */
+    public function deletePublicKey($publicKey) {
+        $this->validatePublicKeyName($publicKey);
+
+        return $this->getCommand('DeletePublicKey', array(
+            'signaturePublicKey' => $this->getPublicKey(),
+            'publicKey' => $publicKey,
+        ))->execute();
+    }
+
+    /**
      * Checks if a given public key exists on the server already
      *
      * @param string $publicKey Public key

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -567,7 +567,6 @@ class ImboClient extends GuzzleClient {
      *
      * @param  string $publicKey Name of the public key to delete
      * @return Model
-     * @throws InvalidArgumentException Thrown when the public key name is invalid
      * @throws InvalidArgumentException If the public key name is invalid
      */
     public function deletePublicKey($publicKey) {
@@ -653,6 +652,24 @@ class ImboClient extends GuzzleClient {
             'signaturePublicKey' => $this->getPublicKey(),
             'publicKey' => $publicKey,
             'rules' => json_encode($rules),
+        ))->execute();
+    }
+
+    /**
+     * Delete an access control rule
+     *
+     * @param string $publicKey Name of the public key which owns the rule
+     * @param string $ruleId ID of the rule to delete
+     * @return Model
+     * @throws InvalidArgumentException Thrown if the public key name is invalid
+     */
+    public function deleteAccessControlRule($publicKey, $ruleId) {
+        $this->validatePublicKeyName($publicKey);
+
+        return $this->getCommand('DeleteAccessControlRule', array(
+            'signaturePublicKey' => $this->getPublicKey(),
+            'publicKey' => $publicKey,
+            'id' => $ruleId,
         ))->execute();
     }
 

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -430,13 +430,11 @@ class ImboClient extends GuzzleClient {
             $query = new Query();
         }
 
-        $response = $this->getCommand('GetGroups', array(
+        return $this->getCommand('GetGroups', array(
             'publicKey' => $this->getPublicKey(),
             'page' => $query->page(),
             'limit' => $query->limit(),
         ))->execute();
-
-        return $response;
     }
 
     /**
@@ -446,12 +444,10 @@ class ImboClient extends GuzzleClient {
      * @return Model
      */
     public function getGroup($groupName) {
-        $response = $this->getCommand('GetGroup', array(
+        return $this->getCommand('GetGroup', array(
             'publicKey' => $this->getPublicKey(),
             'groupName' => $groupName,
         ))->execute();
-
-        return $response;
     }
 
     /**

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -440,6 +440,21 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Get the details of a specific resource group
+     *
+     * @param string $groupName Name of group to get
+     * @return Model
+     */
+    public function getGroup($groupName) {
+        $response = $this->getCommand('GetGroup', array(
+            'publicKey' => $this->getPublicKey(),
+            'groupName' => $groupName,
+        ))->execute();
+
+        return $response;
+    }
+
+    /**
      * Get all server URL's
      *
      * @return string[]

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -479,7 +479,7 @@ class ImboClient extends GuzzleClient {
      * @param string $groupName Name of the group to edit
      * @param array $resources Array of resource names the group should contain
      * @return Model
-     * @throws InvalidArgumentException Throw when group name is invalid or group already exists
+     * @throws InvalidArgumentException Thrown when group name is invalid or group already exists
      */
     public function editGroup($groupName, array $resources) {
         $this->validateGroupName($groupName);
@@ -488,6 +488,22 @@ class ImboClient extends GuzzleClient {
             'publicKey' => $this->getPublicKey(),
             'groupName' => $groupName,
             'resources' => json_encode($resources),
+        ))->execute();
+    }
+
+    /**
+     * Delete a resource group
+     *
+     * @param  string $groupName Name of the group to delete
+     * @return Model
+     * @throws InvalidArgumentException Thrown when the group name is invalid or does not exist
+     */
+    public function deleteGroup($groupName) {
+        $this->validateGroupName($groupName);
+
+        return $this->getCommand('DeleteGroup', array(
+            'publicKey' => $this->getPublicKey(),
+            'groupName' => $groupName,
         ))->execute();
     }
 

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -420,6 +420,26 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Get the available resource groups
+     *
+     * @param Query $query An optional query object
+     * @return Model
+     */
+    public function getGroups(Query $query = null) {
+        if (!$query) {
+            $query = new Query();
+        }
+
+        $response = $this->getCommand('GetGroups', array(
+            'publicKey' => $this->getPublicKey(),
+            'page' => $query->page(),
+            'limit' => $query->limit(),
+        ))->execute();
+
+        return $response;
+    }
+
+    /**
      * Get all server URL's
      *
      * @return string[]
@@ -444,6 +464,15 @@ class ImboClient extends GuzzleClient {
      */
     public function getStatsUrl() {
         return Http\StatsUrl::factory($this->getBaseUrl() . '/stats.json');
+    }
+
+    /**
+     * Get a URL for the groups endpoint
+     *
+     * @return Http\GroupsUrl
+     */
+    public function getGroupsUrl() {
+        return Http\GroupsUrl::factory($this->getBaseUrl() . '/groups.json');
     }
 
     /**

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -147,6 +147,18 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Set the current user
+     *
+     * @param string $user
+     * @return self
+     */
+    public function setUser($user) {
+        $this->getConfig()->set('user', $user);
+
+        return $this;
+    }
+
+    /**
      * Add an image from a path
      *
      * @param string $path A path to an image

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -521,6 +521,29 @@ class ImboClient extends GuzzleClient {
     }
 
     /**
+     * Create a new public/private key pair
+     *
+     * @param string $publicKey Public key to create
+     * @param string $privateKey Private key for the new public key
+     * @return Model
+     */
+    public function addPublicKey($publicKey, $privateKey) {
+        $this->validatePublicKeyName($publicKey);
+
+        if ($this->publicKeyExists($publicKey)) {
+            throw new InvalidArgumentException(
+                'Public key with name "' . $publicKey . '" already exists'
+            );
+        }
+
+        return $this->getCommand('EditPublicKey', array(
+            'signaturePublicKey' => $this->getPublicKey(),
+            'properties' => json_encode(array('privateKey' => $privateKey)),
+            'publicKey' => $publicKey,
+        ))->execute();
+    }
+
+    /**
      * Edit a public/private key pair
      *
      * @param string $publicKey Public key to alter private key for

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -699,7 +699,8 @@ class ImboClient extends GuzzleClient {
     public function getResourceGroupsUrl() {
         return Http\ResourceGroupsUrl::factory(
             $this->getBaseUrl() . '/groups.json',
-            $this->getConfig('privateKey')
+            $this->getConfig('privateKey'),
+            $this->getPublicKey()
         );
     }
 
@@ -710,12 +711,13 @@ class ImboClient extends GuzzleClient {
      * @return Http\GroupUrl
      */
     public function getResourceGroupUrl($groupName) {
-        $url = sprintf(
-            $this->getBaseUrl() . '/groups/%s.json',
-            $groupName
-        );
+        $url = sprintf($this->getBaseUrl() . '/groups/%s.json', $groupName);
 
-        return Http\ResourceGroupUrl::factory($url, $this->getConfig('privateKey'));
+        return Http\ResourceGroupUrl::factory(
+            $url,
+            $this->getConfig('privateKey'),
+            $this->getPublicKey()
+        );
     }
 
     /**
@@ -726,7 +728,8 @@ class ImboClient extends GuzzleClient {
     public function getKeysUrl() {
         return Http\KeysUrl::factory(
             $this->getBaseUrl() . '/keys.json',
-            $this->getConfig('privateKey')
+            $this->getConfig('privateKey'),
+            $this->getPublicKey()
         );
     }
 
@@ -737,12 +740,13 @@ class ImboClient extends GuzzleClient {
      * @return Http\KeyUrl
      */
     public function getKeyUrl($publicKey) {
-        $url = sprintf(
-            $this->getBaseUrl() . '/keys/%s.json',
-            $publicKey
-        );
+        $url = sprintf($this->getBaseUrl() . '/keys/%s', $publicKey);
 
-        return Http\KeyUrl::factory($url, $this->getConfig('privateKey'));
+        return Http\KeyUrl::factory(
+            $url,
+            $this->getConfig('privateKey'),
+            $this->getPublicKey()
+        );
     }
 
     /**
@@ -751,12 +755,13 @@ class ImboClient extends GuzzleClient {
      * @return Http\UserUrl
      */
     public function getUserUrl() {
-        $url = sprintf(
-            $this->getBaseUrl() . '/users/%s.json',
-            $this->getUser()
-        );
+        $url = sprintf($this->getBaseUrl() . '/users/%s.json', $this->getUser());
 
-        return Http\UserUrl::factory($url, $this->getConfig('privateKey'));
+        return Http\UserUrl::factory(
+            $url,
+            $this->getConfig('privateKey'),
+            $this->getPublicKey()
+        );
     }
 
     /**
@@ -765,12 +770,13 @@ class ImboClient extends GuzzleClient {
      * @return Http\ImagesUrl
      */
     public function getImagesUrl() {
-        $url = sprintf(
-            $this->getBaseUrl() . '/users/%s/images.json',
-            $this->getUser()
-        );
+        $url = sprintf($this->getBaseUrl() . '/users/%s/images.json', $this->getUser());
 
-        return Http\ImagesUrl::factory($url, $this->getConfig('privateKey'));
+        return Http\ImagesUrl::factory(
+            $url,
+            $this->getConfig('privateKey'),
+            $this->getPublicKey()
+        );
     }
 
     /**
@@ -786,7 +792,11 @@ class ImboClient extends GuzzleClient {
             $imageIdentifier
         );
 
-        return Http\ImageUrl::factory($url, $this->getConfig('privateKey'));
+        return Http\ImageUrl::factory(
+            $url,
+            $this->getConfig('privateKey'),
+            $this->getPublicKey()
+        );
     }
 
     /**
@@ -802,7 +812,11 @@ class ImboClient extends GuzzleClient {
             $imageIdentifier
         );
 
-        return Http\MetadataUrl::factory($url, $this->getConfig('privateKey'));
+        return Http\MetadataUrl::factory(
+            $url,
+            $this->getConfig('privateKey'),
+            $this->getPublicKey()
+        );
     }
 
     /**

--- a/src/ImboClient/Query.php
+++ b/src/ImboClient/Query.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClient;
+
+/**
+ * Query object for various commands
+ *
+ * @package Client
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ */
+class Query {
+    /**
+     * The page to get
+     *
+     * @var int
+     */
+    protected $page = 1;
+
+    /**
+     * Number of items to get
+     *
+     * @var int
+     */
+    protected $limit = 20;
+
+    /**
+     * Set or get the page property
+     *
+     * @param int $page Give this a value to set the page property
+     * @return int|self
+     */
+    public function page($page = null) {
+        if ($page === null) {
+            return $this->page;
+        }
+
+        $this->page = (int) $page;
+
+        return $this;
+    }
+
+    /**
+     * Set or get the limit property
+     *
+     * @param int $limit Give this a value to set the limit property
+     * @return int|self
+     */
+    public function limit($limit = null) {
+        if ($limit === null) {
+            return $this->limit;
+        }
+
+        $this->limit = (int) $limit;
+
+        return $this;
+    }
+}

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -470,7 +470,7 @@ return array(
         ),
         'GetAccessControlRules' => array(
             'httpMethod' => 'GET',
-            'uri' => '/keys/{publicKey}/access.json',
+            'uri' => 'keys/{publicKey}/access.json',
             'summary' => 'Fetch access control rules for the given public key',
             'parameters' => array(
                 'publicKey' => array(
@@ -491,7 +491,7 @@ return array(
         ),
         'GetAccessControlRule' => array(
             'httpMethod' => 'GET',
-            'uri' => '/keys/{publicKey}/access/{id}.json',
+            'uri' => 'keys/{publicKey}/access/{id}.json',
             'summary' => 'Fetch a given access control rule for the given public key',
             'parameters' => array(
                 'publicKey' => array(
@@ -518,7 +518,7 @@ return array(
         ),
         'AddAccessControlRules' => array(
             'httpMethod' => 'POST',
-            'uri' => '/keys/{publicKey}/access',
+            'uri' => 'keys/{publicKey}/access',
             'summary' => 'Add access control rules to the given public key',
             'parameters' => array(
                 'publicKey' => array(
@@ -541,7 +541,33 @@ return array(
                     'description' => 'The public key used to access the resource',
                 ),
             ),
-            'responseClass' => 'AddAccessControlRules',
+        ),
+
+        'DeleteAccessControlRule' => array(
+            'httpMethod' => 'DELETE',
+            'uri' => 'keys/{publicKey}/access/{id}',
+            'summary' => 'Delete an access control rule',
+            'parameters' => array(
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the public key to delete',
+                ),
+                'signaturePublicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'header',
+                    'sentAs' => 'x-imbo-publickey',
+                    'description' => 'The public key used to access the resource',
+                ),
+                'id' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'ID of the rule to delete',
+                )
+            ),
         ),
     ),
     'models' => array(

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -378,7 +378,7 @@ return array(
         ),
         'EditGroup' => array(
             'httpMethod' => 'PUT',
-            'uri' => 'groups/{groupName}.json',
+            'uri' => 'groups/{groupName}',
             'summary' => 'Edit or add a resource group',
             'parameters' => array(
                 'groupName' => array(
@@ -404,7 +404,7 @@ return array(
         ),
         'DeleteGroup' => array(
             'httpMethod' => 'DELETE',
-            'uri' => 'groups/{groupName}.json',
+            'uri' => 'groups/{groupName}',
             'summary' => 'Delete a resource group',
             'parameters' => array(
                 'groupName' => array(
@@ -424,7 +424,7 @@ return array(
         ),
         'EditPublicKey' => array(
             'httpMethod' => 'PUT',
-            'uri' => 'keys/{publicKey}.json',
+            'uri' => 'keys/{publicKey}',
             'summary' => 'Edit or add a public/private key pair',
             'parameters' => array(
                 'publicKey' => array(
@@ -438,6 +438,26 @@ return array(
                     'required' => true,
                     'location' => 'body',
                     'description' => 'The properties for this public key',
+                ),
+                'signaturePublicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'header',
+                    'sentAs' => 'x-imbo-publickey',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+        ),
+        'DeletePublicKey' => array(
+            'httpMethod' => 'DELETE',
+            'uri' => 'keys/{publicKey}',
+            'summary' => 'Delete a resource group',
+            'parameters' => array(
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the public key to delete',
                 ),
                 'signaturePublicKey' => array(
                     'type' => 'string',

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -26,24 +26,24 @@ return array(
         ),
         'GetUserInfo' => array(
             'httpMethod' => 'GET',
-            'uri' => 'users/{publicKey}.json',
+            'uri' => 'users/{user}.json',
             'summary' => 'Get information about a specific user',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
-                    'description' => 'The public key of the user we want information about',
+                    'description' => 'The user we want information about',
                 ),
             ),
             'responseClass' => 'GetUserInfo',
         ),
         'AddImage' => array(
             'httpMethod' => 'POST',
-            'uri' => 'users/{publicKey}/images',
+            'uri' => 'users/{user}/images',
             'summary' => 'Add an image',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -60,10 +60,10 @@ return array(
         ),
         'DeleteImage' => array(
             'httpMethod' => 'DELETE',
-            'uri' => 'users/{publicKey}/images/{imageIdentifier}',
+            'uri' => 'users/{user}/images/{imageIdentifier}',
             'summary' => 'Delete an image',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -80,10 +80,10 @@ return array(
         ),
         'GetImageProperties' => array(
             'httpMethod' => 'HEAD',
-            'uri' => 'users/{publicKey}/images/{imageIdentifier}',
+            'uri' => 'users/{user}/images/{imageIdentifier}',
             'summary' => 'Get properties of an image',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -100,10 +100,10 @@ return array(
         ),
         'EditMetadata' => array(
             'httpMethod' => 'POST',
-            'uri' => 'users/{publicKey}/images/{imageIdentifier}/metadata',
+            'uri' => 'users/{user}/images/{imageIdentifier}/metadata',
             'summary' => 'Update metadata attached to an image. Supports partial updates',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -125,10 +125,10 @@ return array(
         ),
         'GetMetadata' => array(
             'httpMethod' => 'GET',
-            'uri' => 'users/{publicKey}/images/{imageIdentifier}/metadata.json',
+            'uri' => 'users/{user}/images/{imageIdentifier}/metadata.json',
             'summary' => 'Get metadata attached to an image',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -144,10 +144,10 @@ return array(
         ),
         'ReplaceMetadata' => array(
             'httpMethod' => 'PUT',
-            'uri' => 'users/{publicKey}/images/{imageIdentifier}/metadata',
+            'uri' => 'users/{user}/images/{imageIdentifier}/metadata',
             'summary' => 'Completely replace the metadata attached to an image with new metadata',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -169,10 +169,10 @@ return array(
         ),
         'DeleteMetadata' => array(
             'httpMethod' => 'DELETE',
-            'uri' => 'users/{publicKey}/images/{imageIdentifier}/metadata',
+            'uri' => 'users/{user}/images/{imageIdentifier}/metadata',
             'summary' => 'Delete metadata attached to an image',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -188,10 +188,10 @@ return array(
         ),
         'GetImages' => array(
             'httpMethod' => 'GET',
-            'uri' => 'users/{publicKey}/images.json',
+            'uri' => 'users/{user}/images.json',
             'summary' => 'Fetch information about images owned by a specific user',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -262,10 +262,10 @@ return array(
         ),
         'GenerateShortUrl' => array(
             'httpMethod' => 'POST',
-            'uri' => 'users/{publicKey}/images/{imageIdentifier}/shorturls',
+            'uri' => 'users/{user}/images/{imageIdentifier}/shorturls',
             'summary' => 'Create a short URL to an image with a set of image transformations applied to it',
             'parameters' => array(
-                'publicKey' => array(
+                'user' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
@@ -312,6 +312,10 @@ return array(
             'type' => 'array',
             'properties' => array(
                 'publicKey' => array(
+                    'location' => 'json',
+                    'type' => 'string',
+                ),
+                'user' => array(
                     'location' => 'json',
                     'type' => 'string',
                 ),
@@ -456,6 +460,10 @@ return array(
                                 'type' => 'string',
                             ),
                             'publicKey' => array(
+                                'location' => 'json',
+                                'type' => 'string',
+                            ),
+                            'user' => array(
                                 'location' => 'json',
                                 'type' => 'string',
                             ),

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -356,6 +356,52 @@ return array(
             ),
             'responseClass' => 'GetGroup',
         ),
+        'GroupExists' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'groups/{groupName}.json',
+            'summary' => 'Fetch a specific resource group',
+            'parameters' => array(
+                'groupName' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the resource group',
+                ),
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'query',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+            'responseClass' => 'GetGroup',
+        ),
+        'EditGroup' => array(
+            'httpMethod' => 'PUT',
+            'uri' => 'groups/{groupName}.json',
+            'summary' => 'Edit or add a resource group',
+            'parameters' => array(
+                'groupName' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the group to edit/create',
+                ),
+                'resources' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'body',
+                    'description' => 'The resources the group should have access to',
+                ),
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'header',
+                    'sentAs' => 'x-imbo-publickey',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+        ),
     ),
     'models' => array(
         'GetServerStatus' => array(

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -422,6 +422,32 @@ return array(
                 ),
             ),
         ),
+        'EditPublicKey' => array(
+            'httpMethod' => 'PUT',
+            'uri' => 'keys/{publicKey}.json',
+            'summary' => 'Edit or add a public/private key pair',
+            'parameters' => array(
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the public key to edit/create',
+                ),
+                'properties' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'body',
+                    'description' => 'The properties for this public key',
+                ),
+                'signaturePublicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'header',
+                    'sentAs' => 'x-imbo-publickey',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+        ),
     ),
     'models' => array(
         'GetServerStatus' => array(

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -32,20 +32,6 @@ $search = array(
     )
 );
 
-$accessControlRule = array(
-    'id' => array('location' => 'json'),
-    'resources' => array(
-        'type' => 'array',
-        'location' => 'json',
-        'items' => array('type' => 'string')
-    ),
-    'users' => array(
-        'type' => array('string', 'array'),
-        'location' => 'json',
-        'items' => array('type' => 'string')
-    )
-);
-
 return array(
     'name' => 'Imbo',
     'apiVersion' => '1.0',
@@ -503,6 +489,33 @@ return array(
             ),
             'responseClass' => 'GetAccessControlRules',
         ),
+        'GetAccessControlRule' => array(
+            'httpMethod' => 'GET',
+            'uri' => '/keys/{publicKey}/access/{id}.json',
+            'summary' => 'Fetch a given access control rule for the given public key',
+            'parameters' => array(
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the public key to delete',
+                ),
+                'id' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The id of the rule to retrieve',
+                ),
+                'signaturePublicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'header',
+                    'sentAs' => 'x-imbo-publickey',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+            'responseClass' => 'GetAccessControlRule',
+        ),
     ),
     'models' => array(
         'GetServerStatus' => array(
@@ -741,6 +754,33 @@ return array(
             'additionalProperties' => array(
                 'location' => 'json'
             ),
+        ),
+        'GetAccessControlRule' => array(
+            'type' => 'object',
+            'properties' => array(
+                'id' => array(
+                    'location' => 'json',
+                    'required' => true,
+                    'type' => 'string',
+                ),
+                'resources' => array(
+                    'type' => 'array',
+                    'location' => 'json',
+                    'items' => array(
+                        'type' => 'string'
+                    )
+                ),
+                'group' => array(
+                    'type' => 'string',
+                    'require' => false,
+                    'location' => 'json',
+                ),
+                'users' => array(
+                    'type' => array('string', 'array'),
+                    'location' => 'json',
+                    'items' => array('type' => 'string')
+                )
+            )
         ),
     ),
 );

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -310,7 +310,7 @@ return array(
             ),
             'responseClass' => 'GenerateShortUrl',
         ),
-        'GetGroups' => array(
+        'GetResourceGroups' => array(
             'httpMethod' => 'GET',
             'uri' => 'groups.json',
             'summary' => 'Fetch available resource groups',
@@ -327,16 +327,10 @@ return array(
                     'location' => 'query',
                     'description' => 'Limit the number of groups returned',
                 ),
-                'publicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'query',
-                    'description' => 'The public key used to access the resource',
-                ),
             ),
-            'responseClass' => 'GetGroups',
+            'responseClass' => 'GetResourceGroups',
         ),
-        'GetGroup' => array(
+        'GetResourceGroup' => array(
             'httpMethod' => 'GET',
             'uri' => 'groups/{groupName}.json',
             'summary' => 'Fetch a specific resource group',
@@ -347,16 +341,10 @@ return array(
                     'location' => 'uri',
                     'description' => 'The name of the resource group',
                 ),
-                'publicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'query',
-                    'description' => 'The public key used to access the resource',
-                ),
             ),
-            'responseClass' => 'GetGroup',
+            'responseClass' => 'GetResourceGroup',
         ),
-        'GroupExists' => array(
+        'GetResourceGroup' => array(
             'httpMethod' => 'GET',
             'uri' => 'groups/{groupName}.json',
             'summary' => 'Fetch a specific resource group',
@@ -367,16 +355,10 @@ return array(
                     'location' => 'uri',
                     'description' => 'The name of the resource group',
                 ),
-                'publicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'query',
-                    'description' => 'The public key used to access the resource',
-                ),
             ),
-            'responseClass' => 'GetGroup',
+            'responseClass' => 'GetResourceGroup',
         ),
-        'EditGroup' => array(
+        'EditResourceGroup' => array(
             'httpMethod' => 'PUT',
             'uri' => 'groups/{groupName}',
             'summary' => 'Edit or add a resource group',
@@ -393,16 +375,9 @@ return array(
                     'location' => 'body',
                     'description' => 'The resources the group should have access to',
                 ),
-                'publicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'header',
-                    'sentAs' => 'x-imbo-publickey',
-                    'description' => 'The public key used to access the resource',
-                ),
             ),
         ),
-        'DeleteGroup' => array(
+        'DeleteResourceGroup' => array(
             'httpMethod' => 'DELETE',
             'uri' => 'groups/{groupName}',
             'summary' => 'Delete a resource group',
@@ -412,13 +387,6 @@ return array(
                     'required' => true,
                     'location' => 'uri',
                     'description' => 'The name of the group to delete',
-                ),
-                'publicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'header',
-                    'sentAs' => 'x-imbo-publickey',
-                    'description' => 'The public key used to access the resource',
                 ),
             ),
         ),
@@ -439,32 +407,18 @@ return array(
                     'location' => 'body',
                     'description' => 'The properties for this public key',
                 ),
-                'signaturePublicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'header',
-                    'sentAs' => 'x-imbo-publickey',
-                    'description' => 'The public key used to access the resource',
-                ),
             ),
         ),
         'DeletePublicKey' => array(
             'httpMethod' => 'DELETE',
             'uri' => 'keys/{publicKey}',
-            'summary' => 'Delete a resource group',
+            'summary' => 'Delete a public key',
             'parameters' => array(
                 'publicKey' => array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
                     'description' => 'The name of the public key to delete',
-                ),
-                'signaturePublicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'header',
-                    'sentAs' => 'x-imbo-publickey',
-                    'description' => 'The public key used to access the resource',
                 ),
             ),
         ),
@@ -478,13 +432,6 @@ return array(
                     'required' => true,
                     'location' => 'uri',
                     'description' => 'The name of the public key to delete',
-                ),
-                'signaturePublicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'header',
-                    'sentAs' => 'x-imbo-publickey',
-                    'description' => 'The public key used to access the resource',
                 ),
             ),
             'responseClass' => 'GetAccessControlRules',
@@ -506,13 +453,6 @@ return array(
                     'location' => 'uri',
                     'description' => 'The id of the rule to retrieve',
                 ),
-                'signaturePublicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'header',
-                    'sentAs' => 'x-imbo-publickey',
-                    'description' => 'The public key used to access the resource',
-                ),
             ),
             'responseClass' => 'GetAccessControlRule',
         ),
@@ -533,13 +473,6 @@ return array(
                     'location' => 'body',
                     'description' => 'Access control rules represented as JSON',
                 ),
-                'signaturePublicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'header',
-                    'sentAs' => 'x-imbo-publickey',
-                    'description' => 'The public key used to access the resource',
-                ),
             ),
         ),
 
@@ -553,13 +486,6 @@ return array(
                     'required' => true,
                     'location' => 'uri',
                     'description' => 'The name of the public key to delete',
-                ),
-                'signaturePublicKey' => array(
-                    'type' => 'string',
-                    'required' => true,
-                    'location' => 'header',
-                    'sentAs' => 'x-imbo-publickey',
-                    'description' => 'The public key used to access the resource',
                 ),
                 'id' => array(
                     'type' => 'string',
@@ -765,7 +691,7 @@ return array(
                 ),
             ),
         ),
-        'GetGroups' => array(
+        'GetResourceGroups' => array(
             'type' => 'object',
             'properties' => array(
                 'search' => $search,
@@ -790,7 +716,7 @@ return array(
                 ),
             ),
         ),
-        'GetGroup' => array(
+        'GetResourceGroup' => array(
             'type' => 'object',
             'properties' => array(
                 'resources' => array(

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -498,7 +498,7 @@ return array(
                     'type' => 'string',
                     'required' => true,
                     'location' => 'uri',
-                    'description' => 'The name of the public key to delete',
+                    'description' => 'The name of the public key to retrieve the rule from',
                 ),
                 'id' => array(
                     'type' => 'string',
@@ -515,6 +515,33 @@ return array(
                 ),
             ),
             'responseClass' => 'GetAccessControlRule',
+        ),
+        'AddAccessControlRules' => array(
+            'httpMethod' => 'POST',
+            'uri' => '/keys/{publicKey}/access',
+            'summary' => 'Add access control rules to the given public key',
+            'parameters' => array(
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the public key to add rules to',
+                ),
+                'rules' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'body',
+                    'description' => 'Access control rules represented as JSON',
+                ),
+                'signaturePublicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'header',
+                    'sentAs' => 'x-imbo-publickey',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+            'responseClass' => 'AddAccessControlRules',
         ),
     ),
     'models' => array(
@@ -782,5 +809,9 @@ return array(
                 )
             )
         ),
+        'AddAccessControlRules' => array(
+            'type' => 'object',
+            'properties' => array(),
+        )
     ),
 );

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -336,6 +336,26 @@ return array(
             ),
             'responseClass' => 'GetGroups',
         ),
+        'GetGroup' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'groups/{groupName}.json',
+            'summary' => 'Fetch a specific resource group',
+            'parameters' => array(
+                'groupName' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the resource group',
+                ),
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'query',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+            'responseClass' => 'GetGroup',
+        ),
     ),
     'models' => array(
         'GetServerStatus' => array(
@@ -553,6 +573,18 @@ return array(
                                 ),
                             ),
                         ),
+                    ),
+                ),
+            ),
+        ),
+        'GetGroup' => array(
+            'type' => 'object',
+            'properties' => array(
+                'resources' => array(
+                    'location' => 'json',
+                    'type' => 'array',
+                    'items' => array(
+                        'type' => 'string'
                     ),
                 ),
             ),

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -402,6 +402,26 @@ return array(
                 ),
             ),
         ),
+        'DeleteGroup' => array(
+            'httpMethod' => 'DELETE',
+            'uri' => 'groups/{groupName}.json',
+            'summary' => 'Delete a resource group',
+            'parameters' => array(
+                'groupName' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the group to delete',
+                ),
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'header',
+                    'sentAs' => 'x-imbo-publickey',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+        ),
     ),
     'models' => array(
         'GetServerStatus' => array(

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -8,6 +8,30 @@
  * distributed with this source code.
  */
 
+// Reused in various list resources
+$search = array(
+    'location' => 'json',
+    'type' => 'object',
+    'properties' => array(
+        'limit' => array(
+            'location' => 'json',
+            'type' => 'integer',
+        ),
+        'page' => array(
+            'location' => 'json',
+            'type' => 'integer',
+        ),
+        'hits' => array(
+            'location' => 'json',
+            'type' => 'integer',
+        ),
+        'count' => array(
+            'location' => 'json',
+            'type' => 'integer',
+        )
+    )
+);
+
 return array(
     'name' => 'Imbo',
     'apiVersion' => '1.0',
@@ -286,6 +310,32 @@ return array(
             ),
             'responseClass' => 'GenerateShortUrl',
         ),
+        'GetGroups' => array(
+            'httpMethod' => 'GET',
+            'uri' => 'groups.json',
+            'summary' => 'Fetch available resource groups',
+            'parameters' => array(
+                'page' => array(
+                    'type' => 'integer',
+                    'required' => false,
+                    'location' => 'query',
+                    'description' => 'Which page to fetch from',
+                ),
+                'limit' => array(
+                    'type' => 'integer',
+                    'required' => false,
+                    'location' => 'query',
+                    'description' => 'Limit the number of groups returned',
+                ),
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'query',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+            'responseClass' => 'GetGroups',
+        ),
     ),
     'models' => array(
         'GetServerStatus' => array(
@@ -406,10 +456,7 @@ return array(
         'GetImages' => array(
             'type' => 'array',
             'properties' => array(
-                'search' => array(
-                    'location' => 'json',
-                    'type' => 'string',
-                ),
+                'search' => $search,
                 'images' => array(
                     'location' => 'json',
                     'type' => 'array',
@@ -482,6 +529,31 @@ return array(
                 'status' => array(
                     'location' => 'statusCode',
                     'type' => 'integer',
+                ),
+            ),
+        ),
+        'GetGroups' => array(
+            'type' => 'array',
+            'properties' => array(
+                'search' => $search,
+                'groups' => array(
+                    'location' => 'json',
+                    'type' => 'array',
+                    'items' => array(
+                        'type' => 'object',
+                        'properties' => array(
+                            'name' => array(
+                                'location' => 'json',
+                            ),
+                            'resources' => array(
+                                'location' => 'json',
+                                'type' => 'array',
+                                'items' => array(
+                                    'type' => 'string'
+                                ),
+                            ),
+                        ),
+                    ),
                 ),
             ),
         ),

--- a/src/ImboClient/service.php
+++ b/src/ImboClient/service.php
@@ -32,6 +32,20 @@ $search = array(
     )
 );
 
+$accessControlRule = array(
+    'id' => array('location' => 'json'),
+    'resources' => array(
+        'type' => 'array',
+        'location' => 'json',
+        'items' => array('type' => 'string')
+    ),
+    'users' => array(
+        'type' => array('string', 'array'),
+        'location' => 'json',
+        'items' => array('type' => 'string')
+    )
+);
+
 return array(
     'name' => 'Imbo',
     'apiVersion' => '1.0',
@@ -468,10 +482,31 @@ return array(
                 ),
             ),
         ),
+        'GetAccessControlRules' => array(
+            'httpMethod' => 'GET',
+            'uri' => '/keys/{publicKey}/access.json',
+            'summary' => 'Fetch access control rules for the given public key',
+            'parameters' => array(
+                'publicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'uri',
+                    'description' => 'The name of the public key to delete',
+                ),
+                'signaturePublicKey' => array(
+                    'type' => 'string',
+                    'required' => true,
+                    'location' => 'header',
+                    'sentAs' => 'x-imbo-publickey',
+                    'description' => 'The public key used to access the resource',
+                ),
+            ),
+            'responseClass' => 'GetAccessControlRules',
+        ),
     ),
     'models' => array(
         'GetServerStatus' => array(
-            'type' => 'array',
+            'type' => 'object',
             'properties' => array(
                 'status' => array(
                     'location' => 'statusCode',
@@ -491,7 +526,7 @@ return array(
             ),
         ),
         'GetUserInfo' => array(
-            'type' => 'array',
+            'type' => 'object',
             'properties' => array(
                 'publicKey' => array(
                     'location' => 'json',
@@ -515,7 +550,7 @@ return array(
             ),
         ),
         'AddImage' => array(
-            'type' => 'array',
+            'type' => 'object',
             'properties' => array(
                 'imageIdentifier' => array(
                     'location' => 'json',
@@ -540,7 +575,7 @@ return array(
             ),
         ),
         'DeleteImage' => array(
-            'type' => 'array',
+            'type' => 'object',
             'properties' => array(
                 'imageIdentifier' => array(
                     'location' => 'json',
@@ -553,7 +588,7 @@ return array(
             ),
         ),
         'GetImageProperties' => array(
-            'type' => 'array',
+            'type' => 'object',
             'properties' => array(
                 'width' => array(
                     'location' => 'header',
@@ -586,7 +621,7 @@ return array(
             ),
         ),
         'GetImages' => array(
-            'type' => 'array',
+            'type' => 'object',
             'properties' => array(
                 'search' => $search,
                 'images' => array(
@@ -652,7 +687,7 @@ return array(
             ),
         ),
         'GenerateShortUrl' => array(
-            'type' => 'array',
+            'type' => 'object',
             'properties' => array(
                 'id' => array(
                     'location' => 'json',
@@ -665,7 +700,7 @@ return array(
             ),
         ),
         'GetGroups' => array(
-            'type' => 'array',
+            'type' => 'object',
             'properties' => array(
                 'search' => $search,
                 'groups' => array(
@@ -699,6 +734,12 @@ return array(
                         'type' => 'string'
                     ),
                 ),
+            ),
+        ),
+        'GetAccessControlRules' => array(
+            'type' => 'array',
+            'additionalProperties' => array(
+                'location' => 'json'
             ),
         ),
     ),

--- a/tests/ImboClientTest/EventSubscriber/PublicKeyTest.php
+++ b/tests/ImboClientTest/EventSubscriber/PublicKeyTest.php
@@ -72,8 +72,15 @@ class PublicKeyTest extends \PHPUnit_Framework_TestCase {
         $client->expects($this->once())->method('getUser')->will($this->returnValue($user));
         $client->expects($this->once())->method('getPublicKey')->will($this->returnValue($publicKey));
 
+        $query = $this->getMock('Guzzle\Http\QueryString');
+        $query->expects($this->once())->method('hasKey')->with('publicKey')->will($this->returnValue(false));
+
+        $url = $this->getMockBuilder('Guzzle\Http\Url')->disableOriginalConstructor()->getMock();
+        $url->expects($this->any())->method('getQuery')->will($this->returnValue($query));
+
         $request = $this->getMockBuilder('Guzzle\Http\Message\Request')->disableOriginalConstructor()->getMock();
         $request->expects($this->once())->method('getClient')->will($this->returnValue($client));
+        $request->expects($this->once())->method('getUrl')->will($this->returnValue($url));
 
         $command = $this->getMock('Guzzle\Service\Command\CommandInterface');
         $command->expects($this->any())->method('getRequest')->will($this->returnValue($request));
@@ -83,6 +90,27 @@ class PublicKeyTest extends \PHPUnit_Framework_TestCase {
         } else {
             $request->expects($this->once())->method('setHeader')->with('X-Imbo-PublicKey', $publicKey);
         }
+
+        $event = new Event();
+        $event['command'] = $command;
+
+        $this->subscriber->addPublicKey($event);
+    }
+
+    public function testFallsBackIfPublicKeyInQueryString() {
+        $query = $this->getMock('Guzzle\Http\QueryString');
+        $query->expects($this->once())->method('hasKey')->with('publicKey')->will($this->returnValue(true));
+
+        $url = $this->getMockBuilder('Guzzle\Http\Url')->disableOriginalConstructor()->getMock();
+        $url->expects($this->any())->method('getQuery')->will($this->returnValue($query));
+
+        $request = $this->getMockBuilder('Guzzle\Http\Message\Request')->disableOriginalConstructor()->getMock();
+        $request->expects($this->once())->method('getUrl')->will($this->returnValue($url));
+
+        $command = $this->getMock('Guzzle\Service\Command\CommandInterface');
+        $command->expects($this->any())->method('getRequest')->will($this->returnValue($request));
+
+        $request->expects($this->never())->method('setHeader');
 
         $event = new Event();
         $event['command'] = $command;

--- a/tests/ImboClientTest/EventSubscriber/PublicKeyTest.php
+++ b/tests/ImboClientTest/EventSubscriber/PublicKeyTest.php
@@ -46,17 +46,17 @@ class PublicKeyTest extends \PHPUnit_Framework_TestCase {
      */
     public function getCommands() {
         return array(
-            array('GetUserInfo', 'user', 'publicKey', true),
-            array('GetUserInfo', 'user', 'user', false),
-            array('GetImages', 'user', 'publicKey', true),
-            array('GetImageProperties', 'user', 'user', false),
-            array('GetMetadata', 'user', 'publicKey', true),
+            array('user', 'publicKey', true),
+            array('user', 'user', false),
+            array('user', 'publicKey', true),
+            array('user', 'user', false),
+            array('user', 'publicKey', true),
 
-            array('AddImage', 'user', 'publicKey', true),
-            array('DeleteImage', 'user', 'publicKey', true),
-            array('ReplaceMetadata', 'user', 'publicKey', true),
-            array('EditMetadata', 'user', 'publicKey', true),
-            array('DeleteMetadata', 'user', 'publicKey', true),
+            array('user', 'publicKey', true),
+            array('user', 'publicKey', true),
+            array('user', 'publicKey', true),
+            array('user', 'publicKey', true),
+            array('user', 'publicKey', true),
         );
     }
 
@@ -67,7 +67,7 @@ class PublicKeyTest extends \PHPUnit_Framework_TestCase {
     /**
      * @dataProvider getCommands
      */
-    public function testAppendsPublicKeyOnlyForSomeCommands($commandName, $user, $publicKey, $shouldAdd) {
+    public function testAddsPublicKeyIfUserAndPublicKeyDiffers($user, $publicKey, $shouldAdd) {
         $client = $this->getMockBuilder('ImboClient\ImboClient')->disableOriginalConstructor()->getMock();
         $client->expects($this->once())->method('getUser')->will($this->returnValue($user));
         $client->expects($this->once())->method('getPublicKey')->will($this->returnValue($publicKey));
@@ -79,19 +79,14 @@ class PublicKeyTest extends \PHPUnit_Framework_TestCase {
         $command->expects($this->any())->method('getRequest')->will($this->returnValue($request));
 
         if (!$shouldAdd) {
-            $request->expects($this->never())->method('getQuery');
-            $command->expects($this->never())->method('getName');
+            $request->expects($this->never())->method('setHeader');
         } else {
-            $query = $this->getMock('Guzzle\Http\QueryString');
-            $query->expects($this->once())->method('set')->with('publicKey', $this->isType('string'));
-
-            $request->expects($this->once())->method('getQuery')->will($this->returnValue($query));
-            $command->expects($this->once())->method('getName')->will($this->returnValue($commandName));
+            $request->expects($this->once())->method('setHeader')->with('X-Imbo-PublicKey', $publicKey);
         }
 
         $event = new Event();
         $event['command'] = $command;
 
-        $this->subscriber->appendPublicKey($event);
+        $this->subscriber->addPublicKey($event);
     }
 }

--- a/tests/ImboClientTest/EventSubscriber/PublicKeyTest.php
+++ b/tests/ImboClientTest/EventSubscriber/PublicKeyTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClientTest\EventSubscriber;
+
+use ImboClient\EventSubscriber\PublicKey,
+    Guzzle\Common\Event,
+    Guzzle\Http\Message\Request;
+
+/**
+ * @package Test suite
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @covers ImboClient\EventSubscriber\PublicKey
+ */
+class PublicKeyTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @var PublicKey
+     */
+    private $subscriber;
+
+    /**
+     * Set up the subscriber
+     */
+    public function setUp() {
+        $this->subscriber = new PublicKey();
+    }
+
+    /**
+     * Tear down the subscriber
+     */
+    public function tearDown() {
+        $this->subscriber = null;
+    }
+
+    /**
+     * Data provider
+     *
+     * @return array[]
+     */
+    public function getCommands() {
+        return array(
+            array('GetUserInfo', 'user', 'publicKey', true),
+            array('GetUserInfo', 'user', 'user', false),
+            array('GetImages', 'user', 'publicKey', true),
+            array('GetImageProperties', 'user', 'user', false),
+            array('GetMetadata', 'user', 'publicKey', true),
+
+            array('AddImage', 'user', 'publicKey', true),
+            array('DeleteImage', 'user', 'publicKey', true),
+            array('ReplaceMetadata', 'user', 'publicKey', true),
+            array('EditMetadata', 'user', 'publicKey', true),
+            array('DeleteMetadata', 'user', 'publicKey', true),
+        );
+    }
+
+    public function testSubscribedEventsIsAnArray() {
+        $this->assertInternalType('array', PublicKey::getSubscribedEvents());
+    }
+
+    /**
+     * @dataProvider getCommands
+     */
+    public function testAppendsPublicKeyOnlyForSomeCommands($commandName, $user, $publicKey, $shouldAdd) {
+        $client = $this->getMockBuilder('ImboClient\ImboClient')->disableOriginalConstructor()->getMock();
+        $client->expects($this->once())->method('getUser')->will($this->returnValue($user));
+        $client->expects($this->once())->method('getPublicKey')->will($this->returnValue($publicKey));
+
+        $request = $this->getMockBuilder('Guzzle\Http\Message\Request')->disableOriginalConstructor()->getMock();
+        $request->expects($this->once())->method('getClient')->will($this->returnValue($client));
+
+        $command = $this->getMock('Guzzle\Service\Command\CommandInterface');
+        $command->expects($this->any())->method('getRequest')->will($this->returnValue($request));
+
+        if (!$shouldAdd) {
+            $request->expects($this->never())->method('getQuery');
+            $command->expects($this->never())->method('getName');
+        } else {
+            $query = $this->getMock('Guzzle\Http\QueryString');
+            $query->expects($this->once())->method('set')->with('publicKey', $this->isType('string'));
+
+            $request->expects($this->once())->method('getQuery')->will($this->returnValue($query));
+            $command->expects($this->once())->method('getName')->will($this->returnValue($commandName));
+        }
+
+        $event = new Event();
+        $event['command'] = $command;
+
+        $this->subscriber->appendPublicKey($event);
+    }
+}

--- a/tests/ImboClientTest/Helper/PublicKeyFallbackTest.php
+++ b/tests/ImboClientTest/Helper/PublicKeyFallbackTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClientTest\Helper;
+
+use ImboClient\Helper\PublicKeyFallback;
+
+/**
+ * @package Test suite
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @covers ImboClient\Helper\PublicKeyFallback
+ */
+class PublicKeyFallbackTest extends \PHPUnit_Framework_TestCase {
+    public function testFallsbackToPublicKey() {
+        $input = array('foo' => 'bar', 'publicKey' => 'espenh');
+        $output = PublicKeyFallback::fallback($input);
+
+        $this->assertSame('espenh', $output['user']);
+        $this->assertSame('espenh', $output['publicKey']);
+    }
+
+    public function testProvidesBackwardsCompatibility() {
+        $input = array('foo' => 'bar', 'user' => 'espenh');
+        $output = PublicKeyFallback::fallback($input);
+
+        $this->assertSame('espenh', $output['user']);
+        $this->assertSame('espenh', $output['publicKey']);
+    }
+}

--- a/tests/ImboClientTest/Http/GroupUrlTest.php
+++ b/tests/ImboClientTest/Http/GroupUrlTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClientTest\Http;
+
+use ImboClient\Http\GroupUrl;
+
+/**
+ * @package Test suite
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @covers ImboClient\Http\GroupUrl
+ */
+class GroupUrlTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * Data provider
+     *
+     * @return array[]
+     */
+    public function getGroupUrls() {
+        return array(
+            'no extension' => array('http://imbo/groups/foobar', 'foobar'),
+            'extension (json)' => array('http://imbo/groups/foobar.json', 'foobar'),
+            'extension (xml)' => array('http://imbo/groups/foobar.xml', 'foobar'),
+            'URL with path prefix' => array('http://imbo/some_prefix/groups/foobar.xml', 'foobar'),
+            'missing public key' => array('http://imbo/', null),
+        );
+    }
+
+    /**
+     * @dataProvider getGroupUrls
+     */
+    public function testCanFetchTheGroupInTheUrl($url, $groupName) {
+        $groupUrl = GroupUrl::factory($url);
+        $this->assertSame($groupName, $groupUrl->getGroup());
+    }
+}

--- a/tests/ImboClientTest/Http/GroupUrlTest.php
+++ b/tests/ImboClientTest/Http/GroupUrlTest.php
@@ -29,7 +29,7 @@ class GroupUrlTest extends \PHPUnit_Framework_TestCase {
             'extension (json)' => array('http://imbo/groups/foobar.json', 'foobar'),
             'extension (xml)' => array('http://imbo/groups/foobar.xml', 'foobar'),
             'URL with path prefix' => array('http://imbo/some_prefix/groups/foobar.xml', 'foobar'),
-            'missing public key' => array('http://imbo/', null),
+            'missing group name' => array('http://imbo/', null),
         );
     }
 

--- a/tests/ImboClientTest/Http/GroupsUrlTest.php
+++ b/tests/ImboClientTest/Http/GroupsUrlTest.php
@@ -10,12 +10,12 @@
 
 namespace ImboClientTest\Http;
 
-use ImboClient\Http\GroupUrl;
+use ImboClient\Http\GroupsUrl;
 
 /**
  * @package Test suite
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
- * @covers ImboClient\Http\GroupUrl
+ * @covers ImboClient\Http\GroupsUrl
  */
 class GroupsUrlTest extends \PHPUnit_Framework_TestCase {
     /**
@@ -36,7 +36,7 @@ class GroupsUrlTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider getGroupsUrls
      */
     public function testCanCreateTheUrl($url) {
-        $groupUrl = GroupUrl::factory($url);
+        $groupUrl = GroupsUrl::factory($url);
         $this->assertSame($url, (string) $groupUrl);
     }
 }

--- a/tests/ImboClientTest/Http/GroupsUrlTest.php
+++ b/tests/ImboClientTest/Http/GroupsUrlTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClientTest\Http;
+
+use ImboClient\Http\GroupUrl;
+
+/**
+ * @package Test suite
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @covers ImboClient\Http\GroupUrl
+ */
+class GroupsUrlTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * Data provider
+     *
+     * @return array[]
+     */
+    public function getGroupsUrls() {
+        return array(
+            'no extension' => array('http://imbo/groups'),
+            'extension (json)' => array('http://imbo/groups.json'),
+            'extension (xml)' => array('http://imbo/groups.xml'),
+            'URL with path prefix' => array('http://imbo/some_prefix/groups.xml'),
+        );
+    }
+
+    /**
+     * @dataProvider getGroupsUrls
+     */
+    public function testCanCreateTheUrl($url) {
+        $groupUrl = GroupUrl::factory($url);
+        $this->assertSame($url, (string) $groupUrl);
+    }
+}

--- a/tests/ImboClientTest/Http/ImageUrlTest.php
+++ b/tests/ImboClientTest/Http/ImageUrlTest.php
@@ -57,6 +57,11 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
                 null,
                 'autoRotate',
             ),
+            'blur' => array(
+                'blur',
+                array(array('mode' => 'adaptive', 'radius' => 3, 'sigma' => 1.4)),
+                'blur:mode=adaptive,radius=3,sigma=1.4'
+            ),
             'border' => array(
                 'border',
                 null,
@@ -97,10 +102,30 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
                 array(2, null, 10, 20, 'center-y'),
                 'crop:width=10,height=20,x=2,mode=center-y'
             ),
+            'contrast' => array(
+                'contrast',
+                null,
+                'contrast'
+            ),
+            'contrast with parameters' => array(
+                'contrast',
+                array(4, 0.7),
+                'contrast:alpha=4,beta=0.7'
+            ),
             'desaturate' => array(
                 'desaturate',
                 null,
                 'desaturate',
+            ),
+            'drawPois' => array(
+                'drawPois',
+                null,
+                'drawPois'
+            ),
+            'drawPois with params' => array(
+                'drawPois',
+                array('bf1942', 3, 40),
+                'drawPois:color=bf1942,borderSize=3,pointSize=40'
             ),
             'flipHorizontally' => array(
                 'flipHorizontally',
@@ -121,6 +146,11 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
                 'histogram',
                 array(2, 3.14, '#f00', '#0f0', '#00f'),
                 'histogram:scale=2,ratio=3.14,red=#f00,green=#0f0,blue=#00f',
+            ),
+            'level' => array(
+                'level',
+                array(3, 'cm'),
+                'level:amount=3,channel=cm',
             ),
             'maxSize with width' => array(
                 'maxSize',
@@ -187,6 +217,31 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
                 null,
                 'sepia:threshold=80',
             ),
+            'sharpen' => array(
+                'sharpen',
+                null,
+                'sharpen'
+            ),
+            'sharpen with params' => array(
+                'sharpen',
+                array(array('preset' => 'strong', 'gain' => 5, 'sigma' => 3)),
+                'sharpen:preset=strong,sigma=3,gain=5'
+            ),
+            'smartSize' => array(
+                'smartSize',
+                array(320, 240),
+                'smartSize:width=320,height=240'
+            ),
+            'smartSize with explicit poi' => array(
+                'smartSize',
+                array(320, 230, null, '55,120'),
+                'smartSize:width=320,height=230,poi=55,120'
+            ),
+            'smartSize with crop closeness' => array(
+                'smartSize',
+                array(320, 230, 'wide'),
+                'smartSize:width=320,height=230,crop=wide'
+            ),
             'strip' => array(
                 'strip',
                 null,
@@ -206,6 +261,16 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
                 'transverse',
                 null,
                 'transverse',
+            ),
+            'vignette' => array(
+                'vignette',
+                null,
+                'vignette'
+            ),
+            'vignette with params' => array(
+                'vignette',
+                array(1.7, 'bf1942', 'f00baa'),
+                'vignette:scale=1.7,outer=bf1942,inner=f00baa'
             ),
             'watermark' => array(
                 'watermark',

--- a/tests/ImboClientTest/Http/ImageUrlTest.php
+++ b/tests/ImboClientTest/Http/ImageUrlTest.php
@@ -417,9 +417,9 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
     /**
      * @dataProvider getImageUrls
      */
-    public function testCanFetchThePublicKeyAndTheImageIdentifierInTheUrl($url, $publicKey, $imageIdentifier) {
+    public function testCanFetchTheUserAndTheImageIdentifierInTheUrl($url, $user, $imageIdentifier) {
         $imageUrl = ImageUrl::factory($url);
-        $this->assertSame($publicKey, $imageUrl->getPublicKey(), 'Could not correctly identify the public key in the URL');
+        $this->assertSame($user, $imageUrl->getUser(), 'Could not correctly identify the user in the URL');
         $this->assertSame($imageIdentifier, $imageUrl->getImageIdentifier(), 'Could not correctly identify the image identifier in the URL');
     }
 

--- a/tests/ImboClientTest/Http/ImageUrlTest.php
+++ b/tests/ImboClientTest/Http/ImageUrlTest.php
@@ -62,6 +62,16 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
                 array(array('mode' => 'adaptive', 'radius' => 3, 'sigma' => 1.4)),
                 'blur:mode=adaptive,radius=3,sigma=1.4'
             ),
+            'blur (motion)' => array(
+                'blur',
+                array(array('mode' => 'motion', 'radius' => 3, 'sigma' => 1.4, 'angle' => 13.3)),
+                'blur:mode=motion,radius=3,sigma=1.4,angle=13.3'
+            ),
+            'blur (radial)' => array(
+                'blur',
+                array(array('mode' => 'radial', 'angle' => 180)),
+                'blur:mode=radial,angle=180'
+            ),
             'border' => array(
                 'border',
                 null,
@@ -354,6 +364,22 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
      */
     public function testCanvasMethodThrowExceptionOnMissingParameters() {
         $this->url->canvas(100, 0);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage width and height must be specified
+     */
+    public function testSmartSizeMethodThrowExceptionOnMissingParameters() {
+        $this->url->smartSize(100, 0);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage `radius` must be specified
+     */
+    public function testBlurMethodThrowExceptionOnMissingParameters() {
+        $this->url->blur(array());
     }
 
     /**

--- a/tests/ImboClientTest/Http/KeyUrlTest.php
+++ b/tests/ImboClientTest/Http/KeyUrlTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClientTest\Http;
+
+use ImboClient\Http\KeyUrl;
+
+/**
+ * @package Test suite
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @covers ImboClient\Http\KeyUrl
+ */
+class KeyUrlTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * Data provider
+     *
+     * @return array[]
+     */
+    public function getKeyUrls() {
+        return array(
+            'no extension' => array('http://imbo/keys/barfoo', 'barfoo'),
+            'extension (json)' => array('http://imbo/keys/barfoo.json', 'barfoo'),
+            'extension (xml)' => array('http://imbo/keys/barfoo.xml', 'barfoo'),
+            'URL with path prefix' => array('http://imbo/some_prefix/keys/barfoo.xml', 'barfoo'),
+            'missing key name' => array('http://imbo/', null),
+        );
+    }
+
+    /**
+     * @dataProvider getKeyUrls
+     */
+    public function testCanFetchTheGroupInTheUrl($url, $groupName) {
+        $keyUrl = KeyUrl::factory($url);
+        $this->assertSame($groupName, $keyUrl->getKey());
+    }
+}

--- a/tests/ImboClientTest/Http/KeysUrlTest.php
+++ b/tests/ImboClientTest/Http/KeysUrlTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClientTest\Http;
+
+use ImboClient\Http\KeysUrl;
+
+/**
+ * @package Test suite
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @covers ImboClient\Http\KeysUrl
+ */
+class KeysUrlTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * Data provider
+     *
+     * @return array[]
+     */
+    public function getKeysUrls() {
+        return array(
+            'no extension' => array('http://imbo/keys'),
+            'extension (json)' => array('http://imbo/keys.json'),
+            'extension (xml)' => array('http://imbo/keys.xml'),
+            'URL with path prefix' => array('http://imbo/some_prefix/keys.xml'),
+        );
+    }
+
+    /**
+     * @dataProvider getKeysUrls
+     */
+    public function testCanCreateTheUrl($url) {
+        $keysUrl = KeysUrl::factory($url);
+        $this->assertSame($url, (string) $keysUrl);
+    }
+}

--- a/tests/ImboClientTest/Http/MetadataUrlTest.php
+++ b/tests/ImboClientTest/Http/MetadataUrlTest.php
@@ -29,7 +29,7 @@ class MetadataUrlTest extends \PHPUnit_Framework_TestCase {
             'extension (json)' => array('http://imbo/users/christer/images/image/metadata.json', 'christer', 'image'),
             'extension (xml)' => array('http://imbo/users/christer/images/image/metadata.xml', 'christer', 'image'),
             'URL with path prefix' => array('http://imbo/some_prefix/users/christer/images/image/metadata', 'christer', 'image'),
-            'missing public key' => array('http://imbo/stats.json', null, null),
+            'missing user' => array('http://imbo/stats.json', null, null),
             'missing image identifier' => array('http://imbo/users/christer/images.json', 'christer', null),
         );
     }
@@ -37,9 +37,9 @@ class MetadataUrlTest extends \PHPUnit_Framework_TestCase {
     /**
      * @dataProvider getMetadataUrls
      */
-    public function testCanFetchThePublicKeyAndTheImageIdentifierInTheUrl($url, $publicKey, $imageIdentifier) {
+    public function testCanFetchTheUserAndTheImageIdentifierInTheUrl($url, $user, $imageIdentifier) {
         $imageUrl = MetadataUrl::factory($url);
-        $this->assertSame($publicKey, $imageUrl->getPublicKey(), 'Could not correctly identify the public key in the URL');
+        $this->assertSame($user, $imageUrl->getUser(), 'Could not correctly identify the user in the URL');
         $this->assertSame($imageIdentifier, $imageUrl->getImageIdentifier(), 'Could not correctly identify the image identifier in the URL');
     }
 }

--- a/tests/ImboClientTest/Http/ResourceGroupUrlTest.php
+++ b/tests/ImboClientTest/Http/ResourceGroupUrlTest.php
@@ -10,14 +10,14 @@
 
 namespace ImboClientTest\Http;
 
-use ImboClient\Http\GroupUrl;
+use ImboClient\Http\ResourceGroupUrl;
 
 /**
  * @package Test suite
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
- * @covers ImboClient\Http\GroupUrl
+ * @covers ImboClient\Http\ResourceGroupUrl
  */
-class GroupUrlTest extends \PHPUnit_Framework_TestCase {
+class ResourceGroupUrlTest extends \PHPUnit_Framework_TestCase {
     /**
      * Data provider
      *
@@ -37,7 +37,7 @@ class GroupUrlTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider getGroupUrls
      */
     public function testCanFetchTheGroupInTheUrl($url, $groupName) {
-        $groupUrl = GroupUrl::factory($url);
+        $groupUrl = ResourceGroupUrl::factory($url);
         $this->assertSame($groupName, $groupUrl->getGroup());
     }
 }

--- a/tests/ImboClientTest/Http/ResourceGroupsUrlTest.php
+++ b/tests/ImboClientTest/Http/ResourceGroupsUrlTest.php
@@ -10,14 +10,14 @@
 
 namespace ImboClientTest\Http;
 
-use ImboClient\Http\GroupsUrl;
+use ImboClient\Http\ResourceGroupsUrl;
 
 /**
  * @package Test suite
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
- * @covers ImboClient\Http\GroupsUrl
+ * @covers ImboClient\Http\ResourceGroupsUrl
  */
-class GroupsUrlTest extends \PHPUnit_Framework_TestCase {
+class ResourceGroupsUrlTest extends \PHPUnit_Framework_TestCase {
     /**
      * Data provider
      *
@@ -36,7 +36,7 @@ class GroupsUrlTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider getGroupsUrls
      */
     public function testCanCreateTheUrl($url) {
-        $groupUrl = GroupsUrl::factory($url);
+        $groupUrl = ResourceGroupsUrl::factory($url);
         $this->assertSame($url, (string) $groupUrl);
     }
 }

--- a/tests/ImboClientTest/Http/UrlTest.php
+++ b/tests/ImboClientTest/Http/UrlTest.php
@@ -81,4 +81,36 @@ class UrlTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($user, $urlInstance->getUser());
         $this->assertSame($publicKey, $urlInstance->getPublicKey());
     }
+
+    public function testAddsPublicKeyIfNoUserSpecified() {
+        $urlInstance = Url::factory('http://imbo/groups.json', 'privkey', 'pubkey-of-win');
+        $this->assertContains('publicKey=pubkey-of-win', (string) $urlInstance);
+        $this->assertContains('accessToken=c357e8616ac57574e1dd670f8', (string) $urlInstance);
+    }
+
+    public function testAddsPublicKeyIfUserAndPublicKeyDiffers() {
+        $urlInstance = Url::factory('http://imbo/users/foo/images', 'privkey', 'pubkey-of-win');
+        $this->assertContains('publicKey=pubkey-of-win', (string) $urlInstance);
+    }
+
+    public function testDoesNotAddPublicKeyIfUserAndPublicKeyIsSame() {
+        $urlInstance = Url::factory('http://imbo/users/foo/images', 'privkey', 'foo');
+        $this->assertNotContains('publicKey=foo', (string) $urlInstance);
+    }
+
+    public function testOverridesPublicKeyIfDifferentPublicKeyPassed() {
+        $urlInstance = Url::factory('http://imbo/users/wat/images?publicKey=omg&accessToken=wtf', 'privkey', 'foo');
+        $this->assertContains('publicKey=foo', (string) $urlInstance);
+        $this->assertContains('accessToken=1a60d466525d55e41fc1e2283b579fe23b846851ef7c2bb', (string) $urlInstance);
+    }
+
+    public function testRemovesPublicKeyIfUserMatchesAndPrivateKeyIsProvided() {
+        $urlInstance = Url::factory('http://imbo/users/wat/images?publicKey=wat&accessToken=wtf', 'oo');
+        $this->assertNotContains('publicKey=', (string) $urlInstance);
+    }
+
+    public function testDoesNotRemovePublicKeyIfNoPrivateKeyIsProvided() {
+        $urlInstance = Url::factory('http://imbo/users/wat/images?publicKey=wat&accessToken=wtf');
+        $this->assertContains('publicKey=wat', (string) $urlInstance);
+    }
 }

--- a/tests/ImboClientTest/Http/UrlTest.php
+++ b/tests/ImboClientTest/Http/UrlTest.php
@@ -59,4 +59,26 @@ class UrlTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame('http://imbo/users/christer.json?accessToken=b85f9a8c2ffd2eb6a550b259e417686cf63b567b2b6972630b8e8519f6bb06b9', (string) $urlInstance);
         $this->assertSame((string) $urlInstance, (string) $urlInstance);
     }
+
+    /**
+     * Get URLs with different user/public key combinations
+     *
+     * @return array[]
+     */
+    public function getUserPubKeyUrls() {
+        return array(
+            'Imbo 1.x compatible fallback' => array('http://imbo/users/christer.json', 'christer', 'christer'),
+            'Imbo 2.x specified public key' => array('http://imbo/users/christer.json?publicKey=foo', 'christer', 'foo'),
+            'URL without user' => array('http://imbo/stats.json?publicKey=foo', null, 'foo'),
+        );
+    }
+
+    /**
+     * @dataProvider getUserPubKeyUrls
+     */
+    public function testCanDifferentiateBetweenUsersAndPublicKeys($url, $user, $publicKey) {
+        $urlInstance = Url::factory($url);
+        $this->assertSame($user, $urlInstance->getUser());
+        $this->assertSame($publicKey, $urlInstance->getPublicKey());
+    }
 }

--- a/tests/ImboClientTest/Http/UserUrlTest.php
+++ b/tests/ImboClientTest/Http/UserUrlTest.php
@@ -25,19 +25,20 @@ class UserUrlTest extends \PHPUnit_Framework_TestCase {
      */
     public function getUserUrls() {
         return array(
-            'no extension' => array('http://imbo/users/christer', 'christer'),
-            'extension (json)' => array('http://imbo/users/christer.json', 'christer'),
-            'extension (xml)' => array('http://imbo/users/christer.xml', 'christer'),
-            'URL with path prefix' => array('http://imbo/some_prefix/users/christer.xml', 'christer'),
-            'missing public key' => array('http://imbo/', null),
+            'no extension' => array('http://imbo/users/christer', 'christer', 'christer'),
+            'extension (json)' => array('http://imbo/users/christer.json?publicKey=foo', 'christer', 'foo'),
+            'extension (xml)' => array('http://imbo/users/christer.xml', 'christer', 'christer'),
+            'URL with path prefix' => array('http://imbo/some_prefix/users/christer.xml?publicKey=z', 'christer', 'z'),
+            'missing public key' => array('http://imbo/?publicKey=bar', null, 'bar'),
         );
     }
 
     /**
      * @dataProvider getUserUrls
      */
-    public function testCanFetchThePublicKeyInTheUrl($url, $publicKey) {
+    public function testCanFetchTheUserAndPublicKeyInTheUrl($url, $user, $publicKey) {
         $userUrl = UserUrl::factory($url);
+        $this->assertSame($user, $userUrl->getUser());
         $this->assertSame($publicKey, $userUrl->getPublicKey());
     }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -602,4 +602,17 @@ class ImboClientTest extends GuzzleTestCase {
         $request = $requests[0];
         $this->assertSame('http://imbo/groups.json?page=2&limit=5&publicKey=christer&accessToken=9f9d18597c57a5fd5687aebd989b750577be90e0651ec8c8813f2e3a4378ac61', urldecode($request->getUrl()));
     }
+
+    public function testCanGetGroup() {
+        $this->setMockResponse($this->client, 'group_get');
+        $response = $this->client->getGroup('images-read');
+
+        $this->assertCount(2, $response['resources']);
+        $this->assertSame('images.get', $response['resources'][0]);
+        $this->assertSame('images.head', $response['resources'][1]);
+
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+        $this->assertSame('http://imbo/groups/images-read.json?publicKey=christer&accessToken=9d1e3884939c0f9d471bb35af69f2e10d6fb2f9cd79cf30e85d3b7ec7bbf3d1a', urldecode($request->getUrl()));
+    }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -789,4 +789,49 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertSame('user', $rule['users'][0]);
         $this->assertSame('user2', $rule['users'][1]);
     }
+
+    public function testCanAddAccessControlRules() {
+        $this->setMockResponse($this->client, 'acl_rules_created');
+
+        $rules = array(
+            array(
+                'group' => 'foo',
+                'users' => array('user1', 'user2')
+            ), array(
+                'resources' => array('res1', 'res2'),
+                'users' => '*'
+            )
+        );
+
+        // Add multiple rules
+        $response = $this->client->addAccessControlRules('some-pubkey', $rules);
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://imbo/keys/some-pubkey/access', urldecode($request->getUrl()));
+        $this->assertSame(json_encode($rules), (string) $request->getBody());
+        $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
+        $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
+    }
+
+    public function testCanAddAccessControlRule() {
+        $this->setMockResponse($this->client, 'acl_rules_created');
+
+        $rule = array(
+            'group' => 'foo',
+            'users' => array('user1', 'user2')
+        );
+
+        // Add single rule
+        $this->client->addAccessControlRule('some-pubkey', $rule);
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://imbo/keys/some-pubkey/access', urldecode($request->getUrl()));
+        $this->assertSame(json_encode([$rule]), (string) $request->getBody());
+        $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
+        $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
+    }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -12,6 +12,7 @@ namespace ImboClientTest;
 
 use ImboClient\ImboClient,
     ImboClient\ImagesQuery,
+    ImboClient\Query,
     Guzzle\Http\Url,
     Guzzle\Http\Message\Response,
     Guzzle\Tests\GuzzleTestCase,
@@ -571,5 +572,34 @@ class ImboClientTest extends GuzzleTestCase {
     public function testThrowsExceptionWhenTryingToGetShortUrlAndGenerateShortUrlFails() {
         $this->setMockResponse($this->client, new Response(400));
         $url = $this->client->getShortUrl($this->client->getImageUrl('image'));
+    }
+
+    public function testCanGetGroups() {
+        $this->setMockResponse($this->client, 'groups_get');
+        $response = $this->client->getGroups();
+
+        $this->assertSame(2, $response['search']['hits']);
+        $this->assertSame(1, $response['search']['page']);
+        $this->assertSame(20, $response['search']['limit']);
+        $this->assertSame(2, $response['search']['count']);
+
+        $this->assertCount(2, $response['groups']);
+        $this->assertSame('images-read', $response['groups'][0]['name']);
+        $this->assertSame('groups-read', $response['groups'][1]['name']);
+        $this->assertCount(2, $response['groups'][0]['resources']);
+        $this->assertCount(4, $response['groups'][1]['resources']);
+    }
+
+    public function testCanGetGroupsUsingAQueryObject() {
+        $this->setMockResponse($this->client, 'groups_get');
+
+        $query = new Query();
+        $query->page(2)->limit(5);
+
+        $response = $this->client->getGroups($query);
+
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+        $this->assertSame('http://imbo/groups.json?page=2&limit=5&publicKey=christer&accessToken=9f9d18597c57a5fd5687aebd989b750577be90e0651ec8c8813f2e3a4378ac61', urldecode($request->getUrl()));
     }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -637,7 +637,7 @@ class ImboClientTest extends GuzzleTestCase {
         $request = $requests[1];
 
         $this->assertSame('PUT', $request->getMethod());
-        $this->assertSame('http://imbo/groups/some-group.json', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/groups/some-group', urldecode($request->getUrl()));
         $this->assertSame('["foo","bar"]', (string) $request->getBody());
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
@@ -660,7 +660,7 @@ class ImboClientTest extends GuzzleTestCase {
         $request = $requests[0];
 
         $this->assertSame('PUT', $request->getMethod());
-        $this->assertSame('http://imbo/groups/some-group.json', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/groups/some-group', urldecode($request->getUrl()));
         $this->assertSame('["foo","bar"]', (string) $request->getBody());
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
@@ -674,7 +674,7 @@ class ImboClientTest extends GuzzleTestCase {
         $request = $requests[0];
 
         $this->assertSame('DELETE', $request->getMethod());
-        $this->assertSame('http://imbo/groups/some-group.json', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/groups/some-group', urldecode($request->getUrl()));
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
     }
@@ -697,7 +697,7 @@ class ImboClientTest extends GuzzleTestCase {
         $request = $requests[0];
 
         $this->assertSame('PUT', $request->getMethod());
-        $this->assertSame('http://imbo/keys/pubkey.json', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/keys/pubkey', urldecode($request->getUrl()));
         $this->assertSame('{"privateKey":"newprivkey"}', (string) $request->getBody());
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
@@ -722,7 +722,7 @@ class ImboClientTest extends GuzzleTestCase {
         $request = $requests[1];
 
         $this->assertSame('PUT', $request->getMethod());
-        $this->assertSame('http://imbo/keys/pubkey.json', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/keys/pubkey', urldecode($request->getUrl()));
         $this->assertSame('{"privateKey":"newprivkey"}', (string) $request->getBody());
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
@@ -735,5 +735,18 @@ class ImboClientTest extends GuzzleTestCase {
     public function testAddPublicKeyThrowsIfAlreadyExists() {
         $this->setMockResponse($this->client, 'public_key_exists');
         $this->client->addPublicKey('pubkey', 'newprivkey');
+    }
+
+    public function testCanDeletePublicKey() {
+        $this->setMockResponse($this->client, 'public_key_deleted');
+        $response = $this->client->deletePublicKey('some-public-key');
+
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('http://imbo/keys/some-public-key', urldecode($request->getUrl()));
+        $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
+        $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
     }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -754,6 +754,10 @@ class ImboClientTest extends GuzzleTestCase {
         $this->setMockResponse($this->client, 'acl_rules_get');
         $response = $this->client->getAccessControlRules('some-pubkey');
 
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+        $this->assertSame('http://imbo/keys/some-pubkey/access.json', urldecode($request->getUrl()));
+
         $this->assertCount(3, $response);
 
         $this->assertSame('images-read', $response[0]['group']);
@@ -770,5 +774,19 @@ class ImboClientTest extends GuzzleTestCase {
 
         $this->assertSame('group.delete', $response[2]['resources'][0]);
         $this->assertSame('group.put', $response[2]['resources'][1]);
+    }
+
+    public function testCanGetAccessControlRule() {
+        $this->setMockResponse($this->client, 'acl_rule_get');
+        $rule = $this->client->getAccessControlRule('some-pubkey', 15);
+
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+        $this->assertSame('http://imbo/keys/some-pubkey/access/15.json', urldecode($request->getUrl()));
+
+        $this->assertSame('images-read', $rule['group']);
+        $this->assertSame(1, $rule['id']);
+        $this->assertSame('user', $rule['users'][0]);
+        $this->assertSame('user2', $rule['users'][1]);
     }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -678,4 +678,14 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
     }
+
+    public function testCanCheckIfAPublicKeyExistsOnTheServer() {
+        $this->setMockResponse($this->client, array(
+            'public_key_exists',
+            'public_key_does_not_exist',
+        ));
+
+        $this->assertTrue($this->client->publicKeyExists('key1'));
+        $this->assertFalse($this->client->publicKeyExists('key2'));
+    }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -749,4 +749,26 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
     }
+
+    public function testCanGetAccessControlRules() {
+        $this->setMockResponse($this->client, 'acl_rules_get');
+        $response = $this->client->getAccessControlRules('some-pubkey');
+
+        $this->assertCount(3, $response);
+
+        $this->assertSame('images-read', $response[0]['group']);
+        $this->assertSame('groups-read', $response[1]['group']);
+
+        $this->assertSame(1, $response[0]['id']);
+        $this->assertSame(2, $response[1]['id']);
+        $this->assertSame(3, $response[2]['id']);
+
+        $this->assertSame('user', $response[0]['users'][0]);
+        $this->assertSame('user2', $response[0]['users'][1]);
+        $this->assertSame('*', $response[1]['users']);
+        $this->assertSame('*', $response[2]['users']);
+
+        $this->assertSame('group.delete', $response[2]['resources'][0]);
+        $this->assertSame('group.put', $response[2]['resources'][1]);
+    }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -840,7 +840,7 @@ class ImboClientTest extends GuzzleTestCase {
 
         $this->assertSame('POST', $request->getMethod());
         $this->assertSame('http://imbo/keys/some-pubkey/access', urldecode($request->getUrl()));
-        $this->assertSame(json_encode([$rule]), (string) $request->getBody());
+        $this->assertSame(json_encode(array($rule)), (string) $request->getBody());
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
     }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -834,4 +834,17 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
     }
+
+    public function testCanDeleteAccessControlRule() {
+        $this->setMockResponse($this->client, 'acl_rule_deleted');
+        $response = $this->client->deleteAccessControlRule('some-public-key', 'bf1942');
+
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('http://imbo/keys/some-public-key/access/bf1942', urldecode($request->getUrl()));
+        $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
+        $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
+    }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -86,6 +86,17 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertSame($this->user, $this->client->getUser());
     }
 
+    public function testCanSetDifferentUserAfterInstantiation() {
+        $this->assertSame($this->user, $this->client->getUser());
+        $this->assertSame($this->client, $this->client->setUser('foobar'));
+        $this->assertSame('foobar', $this->client->getUser());
+
+        $this->assertContains('/users/foobar', (string) $this->client->getUserUrl());
+        $this->assertContains('/users/foobar', (string) $this->client->getImagesUrl());
+        $this->assertContains('/users/foobar', (string) $this->client->getImageUrl('z'));
+        $this->assertContains('/users/foobar', (string) $this->client->getMetadataUrl('z'));
+    }
+
     public function testCanFetchServerStatusWhenEverythingIsOk() {
         $this->setMockResponse($this->client, 'status_ok');
 

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -651,4 +651,18 @@ class ImboClientTest extends GuzzleTestCase {
         $this->setMockResponse($this->client, 'group_exists');
         $response = $this->client->addGroup('some-group', array('foo', 'bar'));
     }
+
+    public function testCanEditGroup() {
+        $this->setMockResponse($this->client, 'group_exists');
+        $response = $this->client->editGroup('some-group', array('foo', 'bar'));
+
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame('http://imbo/groups/some-group.json', urldecode($request->getUrl()));
+        $this->assertSame('["foo","bar"]', (string) $request->getBody());
+        $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
+        $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
+    }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -615,4 +615,14 @@ class ImboClientTest extends GuzzleTestCase {
         $request = $requests[0];
         $this->assertSame('http://imbo/groups/images-read.json?publicKey=christer&accessToken=9d1e3884939c0f9d471bb35af69f2e10d6fb2f9cd79cf30e85d3b7ec7bbf3d1a', urldecode($request->getUrl()));
     }
+
+    public function testCanCheckIfAGroupExistsOnTheServer() {
+        $this->setMockResponse($this->client, array(
+            'group_exists',
+            'group_does_not_exist',
+        ));
+
+        $this->assertTrue($this->client->groupExists('group1'));
+        $this->assertFalse($this->client->groupExists('group2'));
+    }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -171,6 +171,8 @@ class ImboClientTest extends GuzzleTestCase {
             'stats' => array('getStatsUrl', 'ImboClient\Http\StatsUrl'),
             'user' => array('getUserUrl', 'ImboClient\Http\UserUrl'),
             'images' => array('getImagesUrl', 'ImboClient\Http\ImagesUrl'),
+            'groups' => array('getGroupsUrl', 'ImboClient\Http\GroupsUrl'),
+            'keys' => array('getKeysUrl', 'ImboClient\Http\KeysUrl'),
         );
     }
 
@@ -187,6 +189,14 @@ class ImboClientTest extends GuzzleTestCase {
 
     public function testCanCreateMetadataUrls() {
         $this->assertInstanceOf('ImboClient\Http\MetadataUrl', $this->client->getMetadataUrl('identifier'));
+    }
+
+    public function testCanCreateGroupUrls() {
+        $this->assertInstanceOf('ImboClient\Http\GroupUrl', $this->client->getGroupUrl('group'));
+    }
+
+    public function testCanCreateKeyUrls() {
+        $this->assertInstanceOf('ImboClient\Http\KeyUrl', $this->client->getKeyUrl('somekey'));
     }
 
     /**

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -665,4 +665,17 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
     }
+
+    public function testCanDeleteGroup() {
+        $this->setMockResponse($this->client, 'group_deleted');
+        $response = $this->client->deleteGroup('some-group', array('foo', 'bar'));
+
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('http://imbo/groups/some-group.json', urldecode($request->getUrl()));
+        $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
+        $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
+    }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -171,7 +171,7 @@ class ImboClientTest extends GuzzleTestCase {
             'stats' => array('getStatsUrl', 'ImboClient\Http\StatsUrl'),
             'user' => array('getUserUrl', 'ImboClient\Http\UserUrl'),
             'images' => array('getImagesUrl', 'ImboClient\Http\ImagesUrl'),
-            'groups' => array('getGroupsUrl', 'ImboClient\Http\GroupsUrl'),
+            'groups' => array('getResourceGroupsUrl', 'ImboClient\Http\ResourceGroupsUrl'),
             'keys' => array('getKeysUrl', 'ImboClient\Http\KeysUrl'),
         );
     }
@@ -191,8 +191,8 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertInstanceOf('ImboClient\Http\MetadataUrl', $this->client->getMetadataUrl('identifier'));
     }
 
-    public function testCanCreateGroupUrls() {
-        $this->assertInstanceOf('ImboClient\Http\GroupUrl', $this->client->getGroupUrl('group'));
+    public function testCanCreateResourceGroupUrls() {
+        $this->assertInstanceOf('ImboClient\Http\ResourceGroupUrl', $this->client->getResourceGroupUrl('group'));
     }
 
     public function testCanCreateKeyUrls() {
@@ -419,7 +419,7 @@ class ImboClientTest extends GuzzleTestCase {
 
         $requests = $this->getMockedRequests();
         $request = $requests[0];
-        $this->assertSame('http://imbo/users/testuser/images.json?page=2&limit=5&metadata=1&from=123&to=456&fields[0]=width&sort[0]=size&ids[0]=id1&ids[1]=id2&checksums[0]=checksum1&checksums[1]=checksum2&originalChecksums[0]=checksum3&originalChecksums[1]=checksum4&publicKey=christer&accessToken=962bc7a372839a4a0defc206f551ae666b1a2e0fd1dc2a2509794f83b2f6572c', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/users/testuser/images.json?page=2&limit=5&metadata=1&from=123&to=456&fields[0]=width&sort[0]=size&ids[0]=id1&ids[1]=id2&checksums[0]=checksum1&checksums[1]=checksum2&originalChecksums[0]=checksum3&originalChecksums[1]=checksum4&accessToken=01b1aa98aefccd5a50e2325316401fb26976f4fe525b4f33de66f515f8ccd169', urldecode($request->getUrl()));
     }
 
     /**
@@ -584,9 +584,9 @@ class ImboClientTest extends GuzzleTestCase {
         $url = $this->client->getShortUrl($this->client->getImageUrl('image'));
     }
 
-    public function testCanGetGroups() {
+    public function testCanGetResourceGroups() {
         $this->setMockResponse($this->client, 'groups_get');
-        $response = $this->client->getGroups();
+        $response = $this->client->getResourceGroups();
 
         $this->assertSame(2, $response['search']['hits']);
         $this->assertSame(1, $response['search']['page']);
@@ -600,22 +600,22 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertCount(4, $response['groups'][1]['resources']);
     }
 
-    public function testCanGetGroupsUsingAQueryObject() {
+    public function testCanGetResourceGroupsUsingAQueryObject() {
         $this->setMockResponse($this->client, 'groups_get');
 
         $query = new Query();
         $query->page(2)->limit(5);
 
-        $response = $this->client->getGroups($query);
+        $response = $this->client->getResourceGroups($query);
 
         $requests = $this->getMockedRequests();
         $request = $requests[0];
-        $this->assertSame('http://imbo/groups.json?page=2&limit=5&publicKey=christer&accessToken=9f9d18597c57a5fd5687aebd989b750577be90e0651ec8c8813f2e3a4378ac61', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/groups.json?page=2&limit=5&accessToken=2e1f640dc7e72e17703957dfb773f3cc58423df28fe97c481f702da2b50ddfe9', urldecode($request->getUrl()));
     }
 
-    public function testCanGetGroup() {
+    public function testCanGetResourceGroup() {
         $this->setMockResponse($this->client, 'group_get');
-        $response = $this->client->getGroup('images-read');
+        $response = $this->client->getResourceGroup('images-read');
 
         $this->assertCount(2, $response['resources']);
         $this->assertSame('images.get', $response['resources'][0]);
@@ -623,7 +623,7 @@ class ImboClientTest extends GuzzleTestCase {
 
         $requests = $this->getMockedRequests();
         $request = $requests[0];
-        $this->assertSame('http://imbo/groups/images-read.json?publicKey=christer&accessToken=9d1e3884939c0f9d471bb35af69f2e10d6fb2f9cd79cf30e85d3b7ec7bbf3d1a', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/groups/images-read.json?accessToken=6bc45d67228a0b9b712f01656945465255ecf35ea8ccef9c1b8048e74d58f2f0', urldecode($request->getUrl()));
     }
 
     public function testCanCheckIfAGroupExistsOnTheServer() {
@@ -632,8 +632,8 @@ class ImboClientTest extends GuzzleTestCase {
             'group_does_not_exist',
         ));
 
-        $this->assertTrue($this->client->groupExists('group1'));
-        $this->assertFalse($this->client->groupExists('group2'));
+        $this->assertTrue($this->client->resourceGroupExists('group1'));
+        $this->assertFalse($this->client->resourceGroupExists('group2'));
     }
 
     public function testCanAddGroup() {
@@ -641,7 +641,7 @@ class ImboClientTest extends GuzzleTestCase {
             'group_does_not_exist',
             'group_created'
         ));
-        $response = $this->client->addGroup('some-group', array('foo', 'bar'));
+        $response = $this->client->addResourceGroup('some-group', array('foo', 'bar'));
 
         $requests = $this->getMockedRequests();
         $request = $requests[1];
@@ -655,16 +655,16 @@ class ImboClientTest extends GuzzleTestCase {
 
     /**
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Group with name "some-group" already exists
+     * @expectedExceptionMessage Resource group with name "some-group" already exists
      */
     public function testAddGroupThrowsIfAlreadyExists() {
         $this->setMockResponse($this->client, 'group_exists');
-        $response = $this->client->addGroup('some-group', array('foo', 'bar'));
+        $response = $this->client->addResourceGroup('some-group', array('foo', 'bar'));
     }
 
     public function testCanEditGroup() {
         $this->setMockResponse($this->client, 'group_exists');
-        $response = $this->client->editGroup('some-group', array('foo', 'bar'));
+        $response = $this->client->editResourceGroup('some-group', array('foo', 'bar'));
 
         $requests = $this->getMockedRequests();
         $request = $requests[0];
@@ -678,7 +678,7 @@ class ImboClientTest extends GuzzleTestCase {
 
     public function testCanDeleteGroup() {
         $this->setMockResponse($this->client, 'group_deleted');
-        $response = $this->client->deleteGroup('some-group', array('foo', 'bar'));
+        $response = $this->client->deleteResourceGroup('some-group', array('foo', 'bar'));
 
         $requests = $this->getMockedRequests();
         $request = $requests[0];
@@ -766,7 +766,7 @@ class ImboClientTest extends GuzzleTestCase {
 
         $requests = $this->getMockedRequests();
         $request = $requests[0];
-        $this->assertSame('http://imbo/keys/some-pubkey/access.json', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/keys/some-pubkey/access.json?accessToken=43ccb50a0ea66251eee79ec1f381647a7092ec1c4b26585e28f25911516c3e1a', urldecode($request->getUrl()));
 
         $this->assertCount(3, $response);
 
@@ -792,7 +792,7 @@ class ImboClientTest extends GuzzleTestCase {
 
         $requests = $this->getMockedRequests();
         $request = $requests[0];
-        $this->assertSame('http://imbo/keys/some-pubkey/access/15.json', urldecode($request->getUrl()));
+        $this->assertSame('http://imbo/keys/some-pubkey/access/15.json?accessToken=63c8ed7a13b2aa62a56bcf3fe73b55800ca114acd3aa02fdeb70e7a3ab3ea788', urldecode($request->getUrl()));
 
         $this->assertSame('images-read', $rule['group']);
         $this->assertSame(1, $rule['id']);

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -688,4 +688,26 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertTrue($this->client->publicKeyExists('key1'));
         $this->assertFalse($this->client->publicKeyExists('key2'));
     }
+
+    public function testCanEditPublicKey() {
+        $this->setMockResponse($this->client, 'public_key_created');
+        $response = $this->client->editPublicKey('pubkey', 'newprivkey');
+
+        $requests = $this->getMockedRequests();
+        $request = $requests[0];
+
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame('http://imbo/keys/pubkey.json', urldecode($request->getUrl()));
+        $this->assertSame('{"privateKey":"newprivkey"}', (string) $request->getBody());
+        $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
+        $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Public key can only consist of:
+     */
+    public function testThrowsExceptionWhenEditingPublicKeyWithInvalidCharacters() {
+        $this->client->editPublicKey('foo.bar', 'wat');
+    }
 }

--- a/tests/ImboClientTest/QueryTest.php
+++ b/tests/ImboClientTest/QueryTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboClientTest;
+
+use ImboClient\Query;
+
+/**
+ * @package Test suite
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @covers ImboClient\Query
+ */
+class QueryTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @var Query
+     */
+    private $query;
+
+    /**
+     * Set up the query instance
+     */
+    public function setUp() {
+        $this->query = new Query();
+    }
+
+    /**
+     * Tear down the query instance
+     */
+    public function tearDown() {
+        $this->query = null;
+    }
+
+    public function testCanSetAndGetThePage() {
+        $this->assertSame(1, $this->query->page());
+        $this->assertSame($this->query, $this->query->page(10));
+        $this->assertSame(10, $this->query->page());
+    }
+
+    public function testCanSetAndGetTheLimit() {
+        $this->assertSame(20, $this->query->limit());
+        $this->assertSame($this->query, $this->query->limit(10));
+        $this->assertSame(10, $this->query->limit());
+    }
+}

--- a/tests/response_mocks/acl_rule_deleted
+++ b/tests/response_mocks/acl_rule_deleted
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2014 09:33:30 GMT
+Connection: close

--- a/tests/response_mocks/acl_rule_get
+++ b/tests/response_mocks/acl_rule_get
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2015 09:33:30 GMT
+Connection: close
+Content-Type: application/json
+
+{
+    "id": 1,
+    "group": "images-read",
+    "users": [
+        "user",
+        "user2"
+    ]
+}

--- a/tests/response_mocks/acl_rules_created
+++ b/tests/response_mocks/acl_rules_created
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2015 09:33:30 GMT
+Connection: close

--- a/tests/response_mocks/acl_rules_get
+++ b/tests/response_mocks/acl_rules_get
@@ -1,0 +1,28 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2015 09:33:30 GMT
+Connection: close
+Content-Type: application/json
+
+[
+    {
+        "group": "images-read",
+        "id": 1,
+        "users": [
+            "user",
+            "user2"
+        ]
+    },
+    {
+        "group": "groups-read",
+        "id": 2,
+        "users": "*"
+    },
+    {
+        "id": 3,
+        "resources": [
+            "group.delete",
+            "group.put"
+        ],
+        "users": "*"
+    }
+]

--- a/tests/response_mocks/group_created
+++ b/tests/response_mocks/group_created
@@ -1,0 +1,3 @@
+HTTP/1.1 201 Created
+Date: Thu, 02 Jan 2014 09:33:30 GMT
+Connection: close

--- a/tests/response_mocks/group_deleted
+++ b/tests/response_mocks/group_deleted
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2014 09:33:30 GMT
+Connection: close

--- a/tests/response_mocks/group_does_not_exist
+++ b/tests/response_mocks/group_does_not_exist
@@ -1,0 +1,5 @@
+HTTP/1.1 404 Not Found
+Date: Fri, 10 Jan 2014 09:14:59 GMT
+X-Imbo-Error-Date: Fri, 10 Jan 2014 09:14:59 GMT
+X-Imbo-Error-InternalCode: 0
+X-Imbo-Error-Message: Not Found

--- a/tests/response_mocks/group_exists
+++ b/tests/response_mocks/group_exists
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2014 09:33:30 GMT
+Connection: close
+Content-Type: application/json

--- a/tests/response_mocks/group_get
+++ b/tests/response_mocks/group_get
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Date: Mon, 30 Nov 2015 11:28:30 GMT
+Connection: close
+Content-Type: application/json
+
+{
+    "resources": [
+        "images.get",
+        "images.head"
+    ]
+}

--- a/tests/response_mocks/groups_get
+++ b/tests/response_mocks/groups_get
@@ -1,0 +1,31 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2014 09:33:30 GMT
+Connection: close
+Content-Type: application/json
+
+{
+    "groups": [
+        {
+            "name": "images-read",
+            "resources": [
+                "images.get",
+                "images.head"
+            ]
+        },
+        {
+            "name": "groups-read",
+            "resources": [
+                "group.get",
+                "group.head",
+                "groups.get",
+                "groups.head"
+            ]
+        }
+    ],
+    "search": {
+        "count": 2,
+        "hits": 2,
+        "limit": 20,
+        "page": 1
+    }
+}

--- a/tests/response_mocks/images_get
+++ b/tests/response_mocks/images_get
@@ -37,7 +37,7 @@ Content-Type: application/json
       "height":50,
       "mime":"image\/jpeg",
       "imageIdentifier":"29f7a5488303927ca345416e22f8836e",
-      "publicKey":"christer"
+      "user":"espen"
     }
   ]
 }

--- a/tests/response_mocks/public_key_created
+++ b/tests/response_mocks/public_key_created
@@ -1,0 +1,3 @@
+HTTP/1.1 201 Created
+Date: Thu, 02 Jan 2014 09:33:30 GMT
+Connection: close

--- a/tests/response_mocks/public_key_deleted
+++ b/tests/response_mocks/public_key_deleted
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2014 09:33:30 GMT
+Connection: close

--- a/tests/response_mocks/public_key_does_not_exist
+++ b/tests/response_mocks/public_key_does_not_exist
@@ -1,0 +1,5 @@
+HTTP/1.1 404 Not Found
+Date: Fri, 10 Jan 2014 09:14:59 GMT
+X-Imbo-Error-Date: Fri, 10 Jan 2014 09:14:59 GMT
+X-Imbo-Error-InternalCode: 0
+X-Imbo-Error-Message: Not Found

--- a/tests/response_mocks/public_key_exists
+++ b/tests/response_mocks/public_key_exists
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+Date: Thu, 02 Jan 2014 09:33:30 GMT
+Connection: close

--- a/tests/response_mocks/user_ok_old
+++ b/tests/response_mocks/user_ok_old
@@ -4,7 +4,7 @@ Connection: close
 Content-Type: application/json
 
 {
-  "user": "christer",
+  "publicKey": "christer",
   "numImages": 11,
   "lastModified": "Tue, 09 Apr 2013 07:00:18 GMT"
 }


### PR DESCRIPTION
This pull request makes the client compatible with the upcoming Imbo 2.0, while remaining backwards-compatible with Imbo 1.0. Main changes:

- Change `user` and `public key` meaning to match Imbo 2.0 - variables, documentation etc.
- Add `user` parameter to client constructor/factory methods
- Update URL-classes to normalize and deal with users vs public keys
- Support image URLs with image identifiers outside of hex-range, and with lengths down to 1 character
- Provide backwards-compatibility for the few methods which now return `user` instead of `publicKey` (`getImages()` for instance), by making sure both properties are defined and have the same value.
- Add methods for handling access control - resource groups, access control rules and public keys, including documentation for these.
- Add new transformations to the `ImageUrl`-class

Outside of the Imbo 2.0 scope, I also:
- Changed the code examples in the documentation to use short-array syntax
- Updated readme and license with new copyright year range