### PR TITLE
Query string aggregator fix

### DIFF
--- a/src/ImboClient/Http/QueryAggregator/UnindexedPhpAggregator.php
+++ b/src/ImboClient/Http/QueryAggregator/UnindexedPhpAggregator.php
@@ -1,0 +1,20 @@
+<?php
+namespace ImboClient\Http\QueryAggregator;
+
+use Guzzle\Http\QueryAggregator\QueryAggregatorInterface,
+    Guzzle\Http\QueryString;
+
+/**
+ * Aggregates nested query string variables using PHP style [],
+ * without any numeric indexes ([] vs [0])
+ *
+ */
+class UnindexedPhpAggregator implements QueryAggregatorInterface {
+    public function aggregate($key, $value, QueryString $query) {
+        if ($query->isUrlEncoding()) {
+            return array($query->encodeValue($key . '[]') => array_map(array($query, 'encodeValue'), $value));
+        } else {
+            return array($key . '[]' => $value);
+        }
+    }
+}

--- a/src/ImboClient/Http/QueryAggregator/UnindexedPhpAggregator.php
+++ b/src/ImboClient/Http/QueryAggregator/UnindexedPhpAggregator.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the ImboClient package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
 namespace ImboClient\Http\QueryAggregator;
 
 use Guzzle\Http\QueryAggregator\QueryAggregatorInterface,
@@ -8,6 +16,8 @@ use Guzzle\Http\QueryAggregator\QueryAggregatorInterface,
  * Aggregates nested query string variables using PHP style [],
  * without any numeric indexes ([] vs [0])
  *
+ * @package Client\Http\QueryAggregator
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  */
 class UnindexedPhpAggregator implements QueryAggregatorInterface {
     public function aggregate($key, $value, QueryString $query) {

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -11,6 +11,7 @@
 namespace ImboClient;
 
 use ImboClient\Http,
+    ImboClient\Http\QueryAggregator\UnindexedPhpAggregator,
     ImboClient\Helper\PublicKeyFallback,
     Guzzle\Common\Collection,
     Guzzle\Service\Client as GuzzleClient,
@@ -35,6 +36,13 @@ class ImboClient extends GuzzleClient {
      * @var array
      */
     private $serverUrls = array();
+
+    /**
+     * Query string aggregator to use when encountering duplicates
+     *
+     * @var Guzzle\Http\QueryAggregator\QueryAggregatorInterface
+     */
+    private $queryStringAggregator;
 
     /**
      * The name of the current command
@@ -195,9 +203,15 @@ class ImboClient extends GuzzleClient {
             throw new InvalidArgumentException('URL is missing scheme: ' . (string) $url);
         }
 
-        // Fetch the image we want to add
-        $image = (string) $this->get($url)->send()->getBody();
+        // Make sure we're using array-style querystring with no indexes (t[]= vs t[0]=)
+        $url->getQuery()->setAggregator($this->getQueryStringAggregator());
 
+        // First, instantiate a request, then explicitly set the URL to be the originally
+        // constructed URL. Guzzle returns a modified copy which doesn't use our aggregator
+        $request = $this->get($url)->setUrl($url);
+
+        // Fetch the image we want to add
+        $image = $request->send()->getBody();
         return $this->addImageFromString($image);
     }
 
@@ -1028,5 +1042,18 @@ class ImboClient extends GuzzleClient {
 
             throw $e;
         }
+    }
+
+    /**
+     * Get the query string aggregator to use for requests
+     *
+     * @return Guzzle\Http\QueryAggregator\QueryAggregatorInterface
+     */
+    private function getQueryStringAggregator() {
+        if (!$this->queryStringAggregator) {
+            $this->queryStringAggregator = new UnindexedPhpAggregator();
+        }
+
+        return $this->queryStringAggregator;
     }
 }

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -318,6 +318,22 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Timestamp'));
     }
 
+    public function testCanAddAnImageFromUrlToDifferentImbo() {
+        $this->setMockResponse($this->client, array(
+            new Response(200, array(), file_get_contents(__DIR__ . '/_files/image.png')),
+            'image_created',
+            new Response(200, array(), file_get_contents(__DIR__ . '/_files/image.png')),
+            'image_created',
+        ));
+
+        $this->client->addImageFromUrl('http://imbo/users/foo/images/img?t[]=blur&t[]=desaturate');
+        $this->client->addImageFromUrl('http://imbo/users/foo/images/img?t%5B%5D=blur&t%5B%5D=desaturate');
+
+        $requests = $this->getMockedRequests();
+        $this->assertSame('http://imbo/users/foo/images/img?t%5B%5D=blur&t%5B%5D=desaturate', $requests[0]->getUrl());
+        $this->assertSame('http://imbo/users/foo/images/img?t%5B%5D=blur&t%5B%5D=desaturate', $requests[2]->getUrl());
+    }
+
     /**
      * @expectedException Guzzle\Http\Exception\ClientErrorResponseException
      * @expectedExceptionMessage Not Found


### PR DESCRIPTION
When adding an image from one Imbo installation to another (or from one user to another), any "array style" query parameters are turned from `t[]=` into `t[0]=` - in other words, they are assigned indexes. This causes problems, as the access token was generated without indexes, so it will no longer match.

Had to jump through some hoops to fix this, but by implementing a custom query string aggregator and explicitly setting the URL after a request has been constructed, we're back to the "Imbo way" of doing this.