### PR TITLE
Create ImageUrl factory method

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,6 +97,15 @@ task :test do
   end
 end
 
+desc "Run unit tests without code coverage"
+task :test_no_cc do
+  begin
+    sh %{./vendor/bin/phpunit --verbose -c tests}
+  rescue Exception
+    exit 1
+  end
+end
+
 desc "Generate API documentation using phpdoc"
 task :apidocs do
   system "phpdoc -d #{source} -t #{build}/docs --title \"ImboClient API documentation\""

--- a/src/ImboClient/Http/ImageUrl.php
+++ b/src/ImboClient/Http/ImageUrl.php
@@ -731,7 +731,7 @@ class ImageUrl extends ImagesUrl {
         // string has already been converted to a string
         $this->query->set('t', $this->transformations);
 
-        return parent::__toString();
+        return preg_replace('/t%5B[0-9]+%5D=/', 't%5B%5D=', parent::__toString());
     }
 
     /**
@@ -763,8 +763,8 @@ class ImageUrl extends ImagesUrl {
      * @return string|null
      */
     public function getImageIdentifier() {
-        if (preg_match('#/users/[^/]+/images/(?<imageIdentifier>[^./]+)#', $this->getPath(), $match)) {
-            return $match['imageIdentifier'];
+        if (preg_match('#/users/[^/]+/images/(?<imgId>[^./]+)#', $this->getPath(), $match)) {
+            return $match['imgId'];
         }
 
         return null;

--- a/tests/ImboClientTest/Http/ImageUrlTest.php
+++ b/tests/ImboClientTest/Http/ImageUrlTest.php
@@ -641,12 +641,12 @@ class ImageUrlTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testDoesNotIncludeTransformationQueryParamIfNoTransformationsAdded() {
-        $url  = 'http://imbo/users/bar/images/imgIdentifier.jpg?foo=bar&z=lulz';
+        $url  = 'http://imbo/users/bar/images/imgIdentifier?foo=bar&z=lulz';
 
         $imgUrl = ImageUrl::factory($url);
 
         $this->assertSame(
-            'http://imbo/users/bar/images/imgIdentifier.jpg?foo=bar&z=lulz',
+            'http://imbo/users/bar/images/imgIdentifier?foo=bar&z=lulz',
             (string) $imgUrl
         );
     }


### PR DESCRIPTION
This PR improves the ImageUrl class by adding a custom factory method. It finds any existing transformations and sets those as state, as well as the current image extension (if any).

I also took the liberty of removing the index on image transformations query params, for instance, `t[0]=strip&t[1]=border` is now `t[]=strip&t[]=border`. I did this in a pretty naive manner, only altering actual transformation parameters. This should make it compatible with other clients (JS, Python etc).

This kind of breaks backwards compatibility, if anyone relied on the following:

```php
<?php
$url  = 'http://imbo/users/foo/images/imgIdentifier.jpg?t[]=flipHorizontally&t[]=sepia:threshold=30';
$imgUrl = ImboClient\Http\ImageUrl::factory($url);
echo $imgUrl->desaturate()->autoRotate();
// http://imbo/users/foo-bar/images/imgIdentifier.jpg?t%5B0%5D=desaturate&t%5B1%5D=autoRotate
```

With this PR it will include both the existing transformations (flip and sepia) as well as desaturate and autoRotate), which I think makes more sense. Enough reason to bump to 2.0?