### PR TITLE
Don't allow the client to create image URL's with empty image identifier

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,6 +1,12 @@
 Changelog for ImboClient
 ========================
 
+ImboClient-x.x.x
+----------------
+__N/A__
+
+* #109: Don't allow generation of image URL's with no image identifier (Christer Edvartsen)
+
 ImboClient-2.0.2
 ----------------
 __2015-12-06__

--- a/src/ImboClient/ImboClient.php
+++ b/src/ImboClient/ImboClient.php
@@ -782,10 +782,15 @@ class ImboClient extends GuzzleClient {
     /**
      * Get a URL for the image resource
      *
+     * @throws InvalidArgumentException
      * @param string $imageIdentifier An image identifier
      * @return Http\ImageUrl
      */
     public function getImageUrl($imageIdentifier) {
+        if (empty($imageIdentifier)) {
+            throw new InvalidArgumentException('Missing image identifier');
+        }
+
         $url = sprintf(
             $this->getHostForImageIdentifier($imageIdentifier) . '/users/%s/images/%s',
             $this->getUser(),

--- a/tests/ImboClientTest/ImboClientTest.php
+++ b/tests/ImboClientTest/ImboClientTest.php
@@ -867,4 +867,12 @@ class ImboClientTest extends GuzzleTestCase {
         $this->assertSame('christer', (string) $request->getHeader('x-imbo-publickey'));
         $this->assertTrue($request->hasHeader('X-Imbo-Authenticate-Signature'));
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Missing image identifier
+     */
+    public function testClientShouldNotBeAbleToGenerateImageUrlWithNoImageIdentifier() {
+        echo $this->client->getImageUrl('');
+    }
 }


### PR DESCRIPTION
This PR fixes #109.