### PR TITLE
Upgrade coding-standard dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "guzzlehttp/guzzle": "^7.3"
   },
   "require-dev": {
-    "imbo/imbo-coding-standard": "^2.0",
+    "imbo/imbo-coding-standard": "^2.1",
     "phpunit/phpunit": "^10.0",
     "psalm/plugin-phpunit": "^0.18.4",
     "symfony/var-dumper": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2d2401ab2aa943a60a07b154e52e4e2",
+    "content-hash": "ca3ebb63dfe69d49bbdb20c492686e48",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1308,20 +1308,20 @@
         },
         {
             "name": "imbo/imbo-coding-standard",
-            "version": "v2.0.5",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/imbo/imbo-coding-standard.git",
-                "reference": "03c905451f4b1c33abb6dd9476173ed43b816ce7"
+                "reference": "bd277b3c7cfbd3295d98a9849616ebd8d796d7ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/imbo/imbo-coding-standard/zipball/03c905451f4b1c33abb6dd9476173ed43b816ce7",
-                "reference": "03c905451f4b1c33abb6dd9476173ed43b816ce7",
+                "url": "https://api.github.com/repos/imbo/imbo-coding-standard/zipball/bd277b3c7cfbd3295d98a9849616ebd8d796d7ad",
+                "reference": "bd277b3c7cfbd3295d98a9849616ebd8d796d7ad",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.0"
@@ -1354,9 +1354,9 @@
             ],
             "support": {
                 "issues": "https://github.com/imbo/imbo-coding-standard/issues",
-                "source": "https://github.com/imbo/imbo-coding-standard/tree/v2.0.5"
+                "source": "https://github.com/imbo/imbo-coding-standard/tree/v2.1.1"
             },
-            "time": "2022-05-07T07:24:53+00:00"
+            "time": "2023-07-03T18:44:31+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
# Changed log

- Running the `php ~/composer.phar require imbo/imbo-coding-standard:^2.1 --dev` command to upgrade the coding standard dependency.
- It can avoid the following error message when running the PHP-CS-Fixer action with the coding standard `^2.0` version:

```sh
> php-cs-fixer fix --dry-run --diff
Loaded config Imbo from "/home/localadmin/imboclient-php/.php-cs-fixer.php".

In FixerFactory.php line 180:

  Rule contains conflicting fixers:
  - "blank_lines_before_namespace" with "no_blank_lines_before_namespace"


fix [--path-mode PATH-MODE] [--allow-risky ALLOW-RISKY] [--config CONFIG] [--dry-run] [--rules RULES] [--using-cache USING-CACHE] [--cache-file CACHE-FILE] [--diff] [--format FORMAT] [--stop-on-violation] [--show-progress SHOW-PROGRESS] [--] [<path>...]

Script php-cs-fixer fix --dry-run --diff handling the cs event returned with error code 1
```